### PR TITLE
Change PR template for env.staging

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,7 @@
 - [ ] Je n'ai pas changé de constante
 
 - J'ai ajouté une variable d'environnement :
-  - [ ] Je l'ai ajouté dans env.dev et env.prod aussi
+  - [ ] Je l'ai ajouté dans env.dev, env.stating et env.prod aussi
+  - [ ] J'ai ajouté un message sur le slite pour que la personne qui fait la MEP vérifie que son env.prod est à jour
 
 - Cas d'usage : 


### PR DESCRIPTION
Nouveau template de PR pour suivre les changement de la PR #392 et le commentaire de Chloé : "Ca me fait penser @sophie M il faudrait peut etre mettre un message sur le slite pour qu'a la prochaine mep, avant de lancer le build, la personne qui le lance verifie que son env.prod est bien a jour + lors de la mise dans les stores il faut changer le mail/mdp pour apple".

Qu'en pensez-vous ?