### PR TITLE
COM-2336: remove validation button on single choice question

### DIFF
--- a/src/components/cards/QuizCardFooter/index.tsx
+++ b/src/components/cards/QuizCardFooter/index.tsx
@@ -12,6 +12,7 @@ interface QuizCardFooterProps {
   footerColors,
   explanation: string,
   buttonDisabled?: boolean,
+  hideButton?: boolean,
   onPressFooterButton?: () => void,
 }
 
@@ -22,6 +23,7 @@ const QuizCardFooter = ({
   footerColors,
   explanation,
   buttonDisabled = false,
+  hideButton = false,
   onPressFooterButton,
 }: QuizCardFooterProps) => {
   const style = styles(footerColors.text, footerColors.background);
@@ -33,9 +35,11 @@ const QuizCardFooter = ({
           <Text style={style.explanationText}>{explanation}</Text>
         </View>
       )}
+      {(!hideButton || isValidated) &&
       <QuestionCardFooter onPressButton={onPressFooterButton} buttonCaption={isValidated ? 'Continuer' : 'Valider'}
         arrowColor={footerColors.buttons} index={cardIndex} buttonDisabled={buttonDisabled}
         buttonColor={!buttonDisabled ? footerColors.buttons : GREY[300]} />
+      }
     </>);
 };
 

--- a/src/components/cards/QuizCardFooter/index.tsx
+++ b/src/components/cards/QuizCardFooter/index.tsx
@@ -35,11 +35,9 @@ const QuizCardFooter = ({
           <Text style={style.explanationText}>{explanation}</Text>
         </View>
       )}
-      {(!hideButton || isValidated) &&
       <QuestionCardFooter onPressButton={onPressFooterButton} buttonCaption={isValidated ? 'Continuer' : 'Valider'}
         arrowColor={footerColors.buttons} index={cardIndex} buttonDisabled={buttonDisabled}
-        buttonColor={!buttonDisabled ? footerColors.buttons : GREY[300]} />
-      }
+        buttonColor={!buttonDisabled ? footerColors.buttons : GREY[300]} buttonVisible={!hideButton || isValidated} />
     </>);
 };
 

--- a/src/screens/courses/cardTemplates/SingleChoiceQuestionCard/index.tsx
+++ b/src/screens/courses/cardTemplates/SingleChoiceQuestionCard/index.tsx
@@ -11,6 +11,7 @@ import { GREY, GREEN, ORANGE, PINK } from '../../../../styles/colors';
 import QuizCardFooter from '../../../../components/cards/QuizCardFooter';
 import QuizProposition from '../../../../components/cards/QuizProposition';
 import cardsStyle from '../../../../styles/cards';
+import FooterGradient from '../../../../components/design/FooterGradient';
 import styles from './styles';
 import { quizJingle } from '../../../../core/helpers/utils';
 
@@ -82,6 +83,7 @@ const SingleChoiceQuestionCard = ({
         </View>
       </ScrollView>
       <View style={style.footerContainer}>
+        {!isPressed && <FooterGradient />}
         <QuizCardFooter isValidated={isPressed} isValid={answers[selectedAnswerIndex] === card.qcuGoodAnswer}
           cardIndex={index} footerColors={footerColors} explanation={card.explanation}
           buttonDisabled={!isPressed} hideButton />

--- a/src/screens/courses/cardTemplates/SingleChoiceQuestionCard/index.tsx
+++ b/src/screens/courses/cardTemplates/SingleChoiceQuestionCard/index.tsx
@@ -11,7 +11,6 @@ import { GREY, GREEN, ORANGE, PINK } from '../../../../styles/colors';
 import QuizCardFooter from '../../../../components/cards/QuizCardFooter';
 import QuizProposition from '../../../../components/cards/QuizProposition';
 import cardsStyle from '../../../../styles/cards';
-import FooterGradient from '../../../../components/design/FooterGradient';
 import styles from './styles';
 import { quizJingle } from '../../../../core/helpers/utils';
 
@@ -83,10 +82,9 @@ const SingleChoiceQuestionCard = ({
         </View>
       </ScrollView>
       <View style={style.footerContainer}>
-        {!isPressed && <FooterGradient /> }
         <QuizCardFooter isValidated={isPressed} isValid={answers[selectedAnswerIndex] === card.qcuGoodAnswer}
           cardIndex={index} footerColors={footerColors} explanation={card.explanation}
-          buttonDisabled={!isPressed} />
+          buttonDisabled={!isPressed} hideButton />
       </View>
     </>
   );


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- [x] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui parce que le changement n'est qu'au niveau de l'UI
  - Non parce que

- [x] Je n'envoie pas de nouveau paramètre dans une route
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
- ~~[ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas~~
- ~~[ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas.~~
- [x] Je n'ai pas changé de constante

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] Je l'ai ajouté dans env.dev, env.stating et env.prod aussi
  - [ ] J'ai ajouté un message sur le slite pour que la personne qui fait la MEP vérifie que son env.prod est à jour

- Cas d'usage : sur les cartes QCU je n'ai plus le bouton "Valider" car il ne sert à rien étant donné qu'on n'a pas à cliquer dessus pour valider notre choix
