### PR TITLE
COM-2340: percentage rather than ratio

### DIFF
--- a/src/components/CourseProfileStickyHeader/index.tsx
+++ b/src/components/CourseProfileStickyHeader/index.tsx
@@ -1,29 +1,23 @@
 import React from 'react';
 import { View, Text } from 'react-native';
-import { CourseType } from '../../types/CourseTypes';
 import ProgressBar from '../cards/ProgressBar';
 import styles from './styles';
 
 interface CourseProfileStickyHeaderProps {
-  course: CourseType,
+  progress: number,
   title: string
 }
 
-const CourseProfileStickyHeader = ({ course, title }: CourseProfileStickyHeaderProps) => {
-  const getStepRatio = steps =>
-    `${steps.filter(step => step.progress === 1).length}/${course.subProgram.steps.length}`;
-
-  return (
-    <View style={styles.container}>
-      <Text style={styles.title}>{title}</Text>
-      <View style={styles.progressBarContainer}>
-        <Text style={styles.stepRatio}>{getStepRatio(course.subProgram.steps)}</Text>
-        <View style={styles.progressBar}>
-          <ProgressBar progress={course.progress * 100} />
-        </View>
+const CourseProfileStickyHeader = ({ progress, title }: CourseProfileStickyHeaderProps) => (
+  <View style={styles.container}>
+    <Text style={styles.title}>{title}</Text>
+    <View style={styles.progressBarContainer}>
+      <Text style={styles.progressPercentage}>{(progress * 100).toFixed(0)}%</Text>
+      <View style={styles.progressBar}>
+        <ProgressBar progress={progress * 100} />
       </View>
     </View>
-  );
-};
+  </View>
+);
 
 export default CourseProfileStickyHeader;

--- a/src/components/CourseProfileStickyHeader/styles.ts
+++ b/src/components/CourseProfileStickyHeader/styles.ts
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'flex-end',
   },
-  stepRatio: {
+  progressPercentage: {
     ...FIRA_SANS_REGULAR.SM,
     color: GREY[600],
     marginVertical: MARGIN.XS,

--- a/src/screens/courses/CourseProfile/index.tsx
+++ b/src/screens/courses/CourseProfile/index.tsx
@@ -155,7 +155,7 @@ const CourseProfile = ({ route, navigation, userId, setStatusBarVisible, resetCo
   const getHeader = () => course && has(course, 'subProgram.program') && (
     <View onLayout={getProgressBarY}>
       {isHeaderSticky
-        ? <CourseProfileStickyHeader course={course} title={getTitle()} />
+        ? <CourseProfileStickyHeader progress={course.progress} title={getTitle()} />
         : <View style={styles.progressBarContainer}>
           <Text style={styles.progressBarText}>ÉTAPES</Text>
           <View style={commonStyles.progressBarContainer}>


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- [x] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui parce que changement cosmétique
  - Non parce que

- [x] Je n'envoie pas de nouveau paramètre dans une route
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
- ~~[ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas~~
- ~~[ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas.~~
- [x] Je n'ai pas changé de constante

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] Je l'ai ajouté dans env.dev, env.stating et env.prod aussi
  - [ ] J'ai ajouté un message sur le slite pour que la personne qui fait la MEP vérifie que son env.prod est à jour

- Cas d'usage : mini changement demandé par Romain => sur le sticky header on a un pourcentage plutôt qu'un ratio
