### PR TITLE
COM-2538: fix day bug

### DIFF
--- a/src/components/CalendarIcon/index.tsx
+++ b/src/components/CalendarIcon/index.tsx
@@ -22,11 +22,11 @@ const CalendarIcon = ({ slots, progress = 0 }: CalendarIconProps) => {
     if (slots.length) {
       const slotsDates = [...new Set(slots.map(date => companiDate(date).format(dateFormat)))];
       const nextSlots = slots.filter(slot => companiDate().isSameOrBefore(slot));
-      const date = nextSlots.length ? companiDate(nextSlots[0]).format(dateFormat) : slotsDates[0];
+      const date = nextSlots.length ? nextSlots[0] : slots[0];
 
-      setDayOfWeek(capitalize(companiDate(date, dateFormat).format('ccc')));
-      setDayOfMonth(capitalize(companiDate(date, dateFormat).format('d')));
-      setMonth(capitalize(companiDate(date, dateFormat).format('LLL')));
+      setDayOfWeek(capitalize(companiDate(date).format('ccc')));
+      setDayOfMonth(capitalize(companiDate(date).format('d')));
+      setMonth(capitalize(companiDate(date).format('LLL')));
       setDates(slotsDates);
     }
   }, [slots]);

--- a/src/core/helpers/dates.ts
+++ b/src/core/helpers/dates.ts
@@ -39,6 +39,11 @@ const companiDateFactory = (_date: DateTime) => ({
 
     return this._date <= otherDate;
   },
+  hasSame(miscTypeOtherDate : Date | CompaniDate | string, unit: DateTimeUnit) {
+    const otherDate = instantiateDateTimeFromMisc(miscTypeOtherDate);
+
+    return this._date.hasSame(otherDate, unit);
+  },
   isBefore(miscTypeOtherDate : Date | CompaniDate | string) {
     const otherDate = instantiateDateTimeFromMisc(miscTypeOtherDate);
 

--- a/src/screens/explore/BlendedAbout/index.tsx
+++ b/src/screens/explore/BlendedAbout/index.tsx
@@ -34,12 +34,9 @@ const BlendedAbout = ({ route, navigation }: BlendedAboutProps) => {
 
   useEffect(() => {
     if (dates) {
-      const dateFormat = 'dd/LL/yyyy';
       const datesFirstSlots = dates.reduce((newDatesSlots: Date[], date) => {
-        if (!newDatesSlots
-          .some(slotDate => companiDate(slotDate).format(dateFormat) === companiDate(date).format(dateFormat))) {
-          newDatesSlots.push(date);
-        }
+        if (!newDatesSlots.some(slotDate => companiDate(date).hasSame(slotDate, 'day'))) newDatesSlots.push(date);
+
         return newDatesSlots;
       }, []);
 

--- a/src/screens/explore/BlendedAbout/index.tsx
+++ b/src/screens/explore/BlendedAbout/index.tsx
@@ -35,12 +35,19 @@ const BlendedAbout = ({ route, navigation }: BlendedAboutProps) => {
   useEffect(() => {
     if (dates) {
       const dateFormat = 'dd/LL/yyyy';
-      const slotsDates = [...new Set(dates.map(date => companiDate(date).format(dateFormat)))];
-      setFormattedDates(slotsDates.map((date) => {
-        const dayOfWeek = capitalize(companiDate(date, dateFormat).format('ccc'));
-        const dayOfMonth = capitalize(companiDate(date, dateFormat).format('d'));
-        const month = capitalize(companiDate(date, dateFormat).format('LLL'));
-        const year = capitalize(companiDate(date, dateFormat).format('yyyy'));
+      const datesFirstSlots = dates.reduce((newDatesSlots: Date[], date) => {
+        if (!newDatesSlots
+          .some(slotDate => companiDate(slotDate).format(dateFormat) === companiDate(date).format(dateFormat))) {
+          newDatesSlots.push(date);
+        }
+        return newDatesSlots;
+      }, []);
+
+      setFormattedDates(datesFirstSlots.map((date) => {
+        const dayOfWeek = capitalize(companiDate(date).format('ccc'));
+        const dayOfMonth = capitalize(companiDate(date).format('d'));
+        const month = capitalize(companiDate(date).format('LLL'));
+        const year = capitalize(companiDate(date).format('yyyy'));
         return `${dayOfWeek} ${dayOfMonth} ${month} ${year}`;
       }));
     }


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- [x] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui parce que traitement front uniquement
  - Non parce que

- [x] Je n'envoie pas de nouveau paramètre dans une route
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
- ~~[ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas~~
- ~~[ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas.~~
- [x] Je n'ai pas changé de constante

-~~ J'ai ajouté une variable d'environnement :~~
  - [ ] Je l'ai ajouté dans env.dev, env.stating et env.prod aussi
  - [ ] J'ai ajouté un message sur le slite pour que la personne qui fait la MEP vérifie que son env.prod est à jour

- Cas d'usage : fix du bug de léa : sur les calendar icon et le à propos des formations le jour n'était pas le bon : on avait dimanche 22 novembre au lieu de lundi 22 novembre sur la formation Accueil par exemple
