### PR TITLE
COM-2516: open notification for new course

### DIFF
--- a/src/api/programs.ts
+++ b/src/api/programs.ts
@@ -4,9 +4,10 @@ import Environment from '../../environment';
 import { ElearningProgramType, ProgramListResponseType } from '../types/AxiosTypes';
 
 export default {
-  getELearningPrograms: async (): Promise<ElearningProgramType[]> => {
+  getELearningPrograms: async (params: object | null = null): Promise<ElearningProgramType[]> => {
     const baseURL = await Environment.getBaseUrl();
-    const response: AxiosResponse<ProgramListResponseType> = await axiosLogged.get(`${baseURL}/programs/e-learning`);
+    const response: AxiosResponse<ProgramListResponseType> =
+      await axiosLogged.get(`${baseURL}/programs/e-learning`, { params });
 
     return response.data.data.programs;
   },

--- a/src/core/data/constants.ts
+++ b/src/core/data/constants.ts
@@ -73,6 +73,7 @@ export const SCROLL_SENSIBILITY_WHEN_SWIPE_ENABLED = 22;
 export const DENIED = 'denied';
 export const GRANTED = 'granted';
 export const BLENDED_COURSE_REGISTRATION = 'blended_course_registration';
+export const NEW_ELEARNING_COURSE = 'new_elearning_course';
 
 // CONTEXT
 export const BEFORE_SIGNIN = 'beforeSignin';

--- a/src/core/helpers/notifications.ts
+++ b/src/core/helpers/notifications.ts
@@ -1,12 +1,13 @@
 import { Platform } from 'react-native';
 import Constants from 'expo-constants';
 import * as Notifications from 'expo-notifications';
-import { BLENDED_COURSE_REGISTRATION, GRANTED, DENIED } from '../data/constants';
+import { BLENDED_COURSE_REGISTRATION, GRANTED, DENIED, NEW_ELEARNING_COURSE } from '../data/constants';
 import { navigationRef } from '../../navigationRef';
 import asyncStorage from './asyncStorage';
 import Users from '../../api/users';
 import Courses from '../../api/courses';
-import { BlendedCourseType } from '../../types/CourseTypes';
+import Programs from '../../api/programs';
+import { BlendedCourseType, ELearningProgramType } from '../../types/CourseTypes';
 
 export const registerForPushNotificationsAsync = async () => {
   let finalStatus;
@@ -43,11 +44,17 @@ export const registerForPushNotificationsAsync = async () => {
 
 export const handleNotificationResponse = async (response) => {
   const { type, _id } = response.notification.request.content.data;
-  const course = await Courses.getCourse(_id);
-
   switch (type) {
-    case BLENDED_COURSE_REGISTRATION:
+    case BLENDED_COURSE_REGISTRATION: {
+      const course = await Courses.getCourse(_id);
+
       return navigationRef.current?.navigate('BlendedAbout', { course: course as BlendedCourseType });
+    }
+    case NEW_ELEARNING_COURSE: {
+      const program = await Programs.getELearningPrograms({ _id });
+
+      return navigationRef.current?.navigate('ElearningAbout', { program: program[0] as ELearningProgramType });
+    }
     default:
       return null;
   }


### PR DESCRIPTION
- [ ] J'ai testé sur iphone
- [x] J'ai testé sur android

- [x] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui parce que
  - Non parce que

- [ ] Je n'envoie pas de nouveau paramètre dans une route
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite: le paramètre n'est pas obligatoire
- ~~[ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas~~
- ~~[ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas.~~
- [x] Je n'ai pas changé de constante

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] Je l'ai ajouté dans env.dev, env.stating et env.prod aussi
  - [ ] J'ai ajouté un message sur le slite pour que la personne qui fait la MEP vérifie que son env.prod est à jour

- Cas d'usage : quand une nouvelle formation elearning est publiée, je reçois une notification qui me renvoie vers le à propos de cette formation
⚠️ je n'ai pas testé sur iPhone ⚠️ 

