### PR TITLE
COM-2614: refacto progress

### DIFF
--- a/src/components/ELearningCell/index.tsx
+++ b/src/components/ELearningCell/index.tsx
@@ -36,7 +36,7 @@ const ELearningCell = ({ step, index, profileId, endedActivity = '' }: ELearning
     <View style={[styles.container, isOpen && styles.openedContainer]}>
       <TouchableOpacity activeOpacity={1} onPress={onPressChevron} style={styles.textContainer}>
         <View style={styles.topContainer}>
-          <ProgressPieChart progress={step.progress} />
+          <ProgressPieChart progress={step.progress.eLearning} />
           <StepCellTitle index={index} name={step.name} type={step.type} />
           <FeatherButton name={isOpen ? 'chevron-up' : 'chevron-down' } onPress={onPressChevron} size={ICON.MD}
             color={GREY[500]} style={iconButtonStyle} />

--- a/src/components/steps/LiveCell/index.tsx
+++ b/src/components/steps/LiveCell/index.tsx
@@ -49,7 +49,7 @@ const LiveCell = ({ step, slots = [], index, profileId }: LiveCellProps) => {
       <TouchableOpacity style={[styles.container, styles.upperContainer, isOpen && styles.openedContainer]}
         onPress={onPressChevron} disabled={!step.activities?.length}>
         <TouchableOpacity onPress={openModal}>
-          <CalendarIcon slots={dates} progress={step.progress} />
+          <CalendarIcon slots={dates} progress={step.progress.live} />
         </TouchableOpacity>
         <StepCellTitle index={index} name={step.name} type={step.type} />
         <View style={styles.iconContainer}>

--- a/src/components/steps/NextStepCell/index.tsx
+++ b/src/components/steps/NextStepCell/index.tsx
@@ -16,7 +16,7 @@ type NextSlotsStepType = {
   slots: Date[],
   type: StepType['type'],
   stepIndex: number,
-  progress: number,
+  progress: { live: number },
   courseId: string,
 }
 
@@ -28,7 +28,7 @@ const NextStepCell = ({ nextSlotsStep }: NextStepCellProps) => {
 
   return (
     <TouchableOpacity style={styles.container} onPress={goToCourse}>
-      <CalendarIcon slots={slots} progress={progress}/>
+      <CalendarIcon slots={slots} progress={progress.live}/>
       <StepCellTitle index={stepIndex} name={nextSlotsStep.name} type={nextSlotsStep.type} />
     </TouchableOpacity>
   );

--- a/src/core/helpers/utils.ts
+++ b/src/core/helpers/utils.ts
@@ -1,4 +1,5 @@
 import { Audio } from 'expo-av';
+import { STRICTLY_E_LEARNING } from '../data/constants';
 
 export const capitalize = (s) => {
   if (typeof s !== 'string') return '';
@@ -48,4 +49,9 @@ export const formatIdentity = (identity, format) => {
   }
 
   return values.join(' ');
+};
+export const getCourseProgress = (course) => {
+  if (course.format === STRICTLY_E_LEARNING) return course.progress.eLearning;
+
+  return course.progress.blended;
 };

--- a/src/screens/courses/CourseList/index.tsx
+++ b/src/screens/courses/CourseList/index.tsx
@@ -20,6 +20,7 @@ import { CourseType, BlendedCourseType, SubProgramType } from '../../../types/Co
 import { NextSlotsStepType } from '../../../types/StepTypes';
 import { ActionWithoutPayloadType } from '../../../types/store/StoreType';
 import styles from './styles';
+import { getCourseProgress } from '../../../core/helpers/utils';
 
 interface CourseListProps extends CompositeScreenProps<
 StackScreenProps<RootBottomTabParamList>,
@@ -70,8 +71,8 @@ const courseReducer = (state, action) => {
   switch (action.type) {
     case SET_COURSES:
       return {
-        onGoing: action.payload.filter(course => course.progress < 1),
-        achieved: action.payload.filter(course => course.progress === 1),
+        onGoing: action.payload.filter(course => getCourseProgress(course) < 1),
+        achieved: action.payload.filter(course => getCourseProgress(course) === 1),
       };
     case RESET_COURSES:
       return { onGoing: [], achieved: [] };
@@ -126,7 +127,7 @@ const CourseList = ({ setIsCourse, navigation, loggedUserId }: CourseListProps) 
   };
 
   const renderCourseItem = course => <ProgramCell program={get(course, 'subProgram.program') || {}}
-    onPress={() => onPressProgramCell(course._id, true)} progress={course.progress} misc={course.misc} />;
+    onPress={() => onPressProgramCell(course._id, true)} progress={getCourseProgress(course)} misc={course.misc} />;
 
   const renderSubProgramItem = subProgram => <ProgramCell program={get(subProgram, 'program') || {}}
     onPress={() => onPressProgramCell(subProgram._id, false)} />;

--- a/src/screens/courses/CourseProfile/index.tsx
+++ b/src/screens/courses/CourseProfile/index.tsx
@@ -38,6 +38,7 @@ import CourseProfileStickyHeader from '../../../components/CourseProfileStickyHe
 import { getLoggedUserId } from '../../../store/main/selectors';
 import QuestionnairesContainer from '../../../components/questionnaires/QuestionnairesContainer';
 import { QuestionnaireType } from '../../../types/QuestionnaireType';
+import { getCourseProgress } from '../../../core/helpers/utils';
 
 LogBox.ignoreLogs(['VirtualizedLists should never be nested']);
 
@@ -157,13 +158,13 @@ const CourseProfile = ({ route, navigation, userId, setStatusBarVisible, resetCo
   const getHeader = () => course && has(course, 'subProgram.program') && (
     <View onLayout={getProgressBarY}>
       {isHeaderSticky
-        ? <CourseProfileStickyHeader progress={course.progress} title={getTitle()} />
+        ? <CourseProfileStickyHeader progress={getCourseProgress(course)} title={getTitle()} />
         : <View style={styles.progressBarContainer}>
           <Text style={styles.progressBarText}>ÉTAPES</Text>
           <View style={commonStyles.progressBarContainer}>
-            <ProgressBar progress={course.progress * 100} />
+            <ProgressBar progress={getCourseProgress(course) * 100} />
           </View>
-          <Text style={styles.progressBarText}>{(course.progress * 100).toFixed(0)}%</Text>
+          <Text style={styles.progressBarText}>{(getCourseProgress(course) * 100).toFixed(0)}%</Text>
         </View>
       }
     </View>

--- a/src/screens/profile/Profile/index.tsx
+++ b/src/screens/profile/Profile/index.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { StackScreenProps } from '@react-navigation/stack';
 import { CompositeScreenProps } from '@react-navigation/native';
 import { RootBottomTabParamList, RootStackParamList } from '../../../types/NavigationType';
-import { formatPhone } from '../../../core/helpers/utils';
+import { formatPhone, getCourseProgress } from '../../../core/helpers/utils';
 import NiSecondaryButton from '../../../components/form/SecondaryButton';
 import NiPrimaryButton from '../../../components/form/PrimaryButton';
 import commonStyles from '../../../styles/common';
@@ -37,8 +37,8 @@ const Profile = ({ loggedUser, navigation }: ProfileProps) => {
   const getUserCourses = async () => {
     try {
       const fetchedCourses = await Course.getUserCourses();
-      setOnGoingCoursesCount(fetchedCourses.filter(course => course.progress < 1).length);
-      setAchievedCoursesCount(fetchedCourses.filter(course => course.progress === 1).length);
+      setOnGoingCoursesCount(fetchedCourses.filter(course => getCourseProgress(course) < 1).length);
+      setAchievedCoursesCount(fetchedCourses.filter(course => getCourseProgress(course) === 1).length);
     } catch (e: any) {
       console.error(e);
       setOnGoingCoursesCount(0);

--- a/src/types/StepTypes.tsx
+++ b/src/types/StepTypes.tsx
@@ -3,7 +3,7 @@ import { ActivityType } from './ActivityTypes';
 
 type BaseStepType = {
   _id: string,
-  progress: number,
+  progress: { live:number, eLearning: number },
   type: string,
   name: string,
 }


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- [ ] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui parce que
  - Non parce que on utilise progress.live / progress.eLearning / progress.blended qui sont définis dans le nouveau back

- [x] Je n'envoie pas de nouveau paramètre dans une route
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
- [ ] ~~J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas~~
- [ ] ~~J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas.~~
- [x] Je n'ai pas changé de constante

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] Je l'ai ajouté dans env.dev, env.stating et env.prod aussi
  - [ ] J'ai ajouté un message sur le slite pour que la personne qui fait la MEP vérifie que son env.prod est à jour

- Cas d'usage : la progression s'affiche correctement
TEST : pull dev et comparer qu'on a bien la même progression sur l'appli dev et sur cette branche : 
- créneaux à venir
- progression sur une formation 100% présentielle (pie chart sur la liste des formations + barre sur le profil de la formation)
- progression sur une formation 100 % elearning (pie chart sur la liste des formations + barre sur le profil de la formation)
- progression sur une formation mixte (pie chart sur la liste des formations + barre sur le profil de la formation)
- progression sur une étape eLearning
- progression sur une étape contenant du eLearning et du live
- progression sur une étape live
