### PR TITLE
COM-2721: display theoretical duration for steps

### DIFF
--- a/src/components/ELearningCell/index.tsx
+++ b/src/components/ELearningCell/index.tsx
@@ -36,8 +36,8 @@ const ELearningCell = ({ step, index, profileId, endedActivity = '' }: ELearning
     <View style={[styles.container, isOpen && styles.openedContainer]}>
       <TouchableOpacity activeOpacity={1} onPress={onPressChevron} style={styles.textContainer}>
         <View style={styles.topContainer}>
-          <ProgressPieChart progress={step.progress.eLearning} />
-          <StepCellTitle index={index} name={step.name} type={step.type} />
+          <ProgressPieChart progress={step.progress?.eLearning} />
+          <StepCellTitle index={index} name={step.name} type={step.type} theoreticalHours={step.theoreticalHours} />
           <FeatherButton name={isOpen ? 'chevron-up' : 'chevron-down' } onPress={onPressChevron} size={ICON.MD}
             color={GREY[500]} style={iconButtonStyle} />
         </View>

--- a/src/components/steps/StepCellTitle/index.tsx
+++ b/src/components/steps/StepCellTitle/index.tsx
@@ -1,18 +1,23 @@
 import React from 'react';
 import { View, Text } from 'react-native';
 import { StepType } from '../../../types/StepTypes';
-import { stepTypeOptions } from '../../../core/data/constants';
+import { stepTypeOptions, E_LEARNING } from '../../../core/data/constants';
+import { formatDuration } from '../../../core/helpers/utils';
 import styles from './styles';
 
 type StepCellTitleProps = {
   name: StepType['name'],
   type: StepType['type'],
   index: number,
+  theoreticalHours?: number,
 }
 
-const StepCellTitle = ({ name, type, index }: StepCellTitleProps) => (
+const StepCellTitle = ({ name, type, index, theoreticalHours = 0 }: StepCellTitleProps) => (
   <View style={styles.textContainer}>
-    <Text style={styles.stepType}>{`ÉTAPE ${index + 1} - ${stepTypeOptions[type]}`}</Text>
+    <Text style={styles.stepType}>
+      {`ÉTAPE ${index + 1} - ${stepTypeOptions[type]}`}
+      {type === E_LEARNING && !!theoreticalHours && ` (${formatDuration(theoreticalHours)})`}
+    </Text>
     <Text lineBreakMode={'tail'} numberOfLines={2} style={styles.stepName}>{name}</Text>
   </View>
 );

--- a/src/core/helpers/utils.ts
+++ b/src/core/helpers/utils.ts
@@ -55,3 +55,12 @@ export const getCourseProgress = (course) => {
 
   return course.progress.blended;
 };
+
+export const formatDuration = (durationHours) => {
+  const hours = Math.floor(durationHours);
+  const minutes = Math.round((durationHours % 1) * 60);
+  if (!hours) return `${minutes}min`;
+  if (!minutes) return `${hours}h`;
+
+  return `${hours}h ${minutes.toString().padStart(2, '0')}min`;
+};

--- a/src/types/StepTypes.tsx
+++ b/src/types/StepTypes.tsx
@@ -8,7 +8,8 @@ type BaseStepType = {
   name: string,
 }
 
-export type ELearningStepType = BaseStepType & { type: typeof E_LEARNING, activities: ActivityType[] }
+export type ELearningStepType = BaseStepType &
+{ type: typeof E_LEARNING, activities: ActivityType[], theoreticalHours: number }
 export type LiveStepType = BaseStepType & { type: typeof ON_SITE | typeof REMOTE, activities: ActivityType[] }
 export type StepType = ELearningStepType | LiveStepType;
 


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] ~~Mes changements entrainent une incompatibilité avec l'ancienne version de l'api~~
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : app-formation / tous

- Cas d'usage : je peux voir la durée d'une étape elearning + boyscout je peux de nouveau accéder aux formations en brouillon (bug en prod)

- Comment tester ? : 
  - aller sur une formation elearning ou mixte : la durée des étapes (si elle est définie) est affichée

_Si tu as lu cette description, pense a réagir avec un :eye:_
