### PR TITLE
COM-2768 unload audio after usage

### DIFF
--- a/src/core/helpers/utils.ts
+++ b/src/core/helpers/utils.ts
@@ -19,19 +19,26 @@ export const formatWordToPlural = (items, text) => (items.length > 1 ? `${text}s
 
 export const capitalizeFirstLetter = s => `${s.charAt(0).toUpperCase()}${s.substr(1)}`;
 
+const loadPlayAndUnloadAudio = async (track) => {
+  const { sound } = await Audio.Sound.createAsync(track);
+
+  await sound.playAsync();
+  sound.setOnPlaybackStatusUpdate((status) => {
+    if (!status.isLoaded || !status.didJustFinish) return;
+    sound.unloadAsync();
+  });
+};
+
 export const quizJingle = async (isGoodAnswer) => {
-  if (isGoodAnswer) {
-    const { sound } = await Audio.Sound.createAsync(require('../../../assets/sounds/good-answer.mp3'));
-    await sound.playAsync();
-  } else {
-    const { sound } = await Audio.Sound.createAsync(require('../../../assets/sounds/wrong-answer.mp3'));
-    await sound.playAsync();
-  }
+  const track = isGoodAnswer
+    ? require('../../../assets/sounds/good-answer.mp3')
+    : require('../../../assets/sounds/wrong-answer.mp3');
+  loadPlayAndUnloadAudio(track);
 };
 
 export const achievementJingle = async () => {
-  const { sound } = await Audio.Sound.createAsync(require('../../../assets/sounds/ended-activity.mp3'));
-  await sound.playAsync();
+  const track = require('../../../assets/sounds/ended-activity.mp3');
+  loadPlayAndUnloadAudio(track);
 };
 export const formatIdentity = (identity, format) => {
   if (!identity) return '';


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] Mes changements entrainent une incompatibilité avec l'ancienne version de l'api
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : apprenant.e

- Cas d'usage : 
  - nettoyage de la memoire apres un jingle. 
  - Je n'ai pas reussi a reproduire le pb sur simu ios. (je n'ai pas testé avec un iphone physique)
  - de la doc expo : https://docs.expo.dev/versions/v43.0.0/sdk/av/#playback-api
  - un commentaire interessant sur github https://github.com/expo/expo/issues/1873#issuecomment-488912452

- Comment tester ? :
   - avec android
   - sur la branche dev : activer une quinzaine de fois le jingle (faire une activité quiz 2-3 fois de suite)  jusqu'a se que le son ne soit plus emis. L'erreur `[Unhandled promise rejection: Error: h.f.c.d.j0.n$b: AudioTrack init failed: 0, Config(44100, 12, 44100)]` s'affiche egalement sur la console.
   - revenir sur cette branche COm-2768, repeter l'operation. Le son ne doit plus se bloquer


Pour repondre a la question de Kenny, une fois le son bloqué par les jingles, les media de carte audio ne se lance pas non plus.
Est-ce qu'on fait une publication a la volé pour corriger le pb en prod ?

_Si tu as lu cette description, pense a réagir avec un :eye:_
