### PR TITLE
COM-2758: display download button

### DIFF
--- a/src/screens/courses/CourseProfile/index.tsx
+++ b/src/screens/courses/CourseProfile/index.tsx
@@ -224,7 +224,7 @@ const CourseProfile = ({ route, navigation, userId, setStatusBarVisible, resetCo
       {getHeader()}
       <FlatList style={styles.flatList} data={course.subProgram.steps} keyExtractor={item => item._id}
         renderItem={renderCells} ItemSeparatorComponent={renderSeparator} />
-      {course.canAccessCompletionCertificate && <View style={styles.buttonContainer}>
+      {course.areLastSlotAttendancesValidated && <View style={styles.buttonContainer}>
         <TouchableOpacity style={styles.buttonContent} onPress={downloadCompletionCertificate}
           disabled={isLoading}>
           {isLoading

--- a/src/screens/courses/CourseProfile/index.tsx
+++ b/src/screens/courses/CourseProfile/index.tsx
@@ -224,7 +224,7 @@ const CourseProfile = ({ route, navigation, userId, setStatusBarVisible, resetCo
       {getHeader()}
       <FlatList style={styles.flatList} data={course.subProgram.steps} keyExtractor={item => item._id}
         renderItem={renderCells} ItemSeparatorComponent={renderSeparator} />
-      {!course.subProgram.isStrictlyELearning && !!get(course, 'slots.length') && <View style={styles.buttonContainer}>
+      {course.canAccessCompletionCertificate && <View style={styles.buttonContainer}>
         <TouchableOpacity style={styles.buttonContent} onPress={downloadCompletionCertificate}
           disabled={isLoading}>
           {isLoading

--- a/src/types/CourseTypes.tsx
+++ b/src/types/CourseTypes.tsx
@@ -53,6 +53,7 @@ type BaseCourseType = {
   _id: string,
   progress: number,
   subProgram: SubProgramType & { program: ProgramType },
+  canAccessCompletionCertificate?: boolean,
 };
 
 export type ELearningCourseType = BaseCourseType & {

--- a/src/types/CourseTypes.tsx
+++ b/src/types/CourseTypes.tsx
@@ -53,7 +53,7 @@ type BaseCourseType = {
   _id: string,
   progress: number,
   subProgram: SubProgramType & { program: ProgramType },
-  canAccessCompletionCertificate?: boolean,
+  areLastSlotAttendancesValidated?: boolean,
 };
 
 export type ELearningCourseType = BaseCourseType & {


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] ~~Mes changements entrainent une incompatibilité avec l'ancienne version de l'api~~
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : mobile / vendeur  tous/rof/admin

- Cas d'usage : je ne vois le bouton de téléchargement que si le dernier créneau a été émargé pour un stagiaire

- Comment tester ? :
  - côté mobile :
    - sur le profil : le nombre de formation s'affiche bien
    - sur la liste des formation : tout s'affiche bien  
    - sur une formation elearning : je ne vois pas le bouton de téléchargement
    - sur une formation mixte en cours ou sans émargement sur le dernier créneau : je ne vois pas le bouton de téléchargement
    - sur une formation mixte dont le dernier créneau a été émargé (peu importe que ça soit le stagiaire concerné ou non) : je vois le bouton de téléchargement d'attestation
  - côté vendeur :  sur la liste des formations sur le profil d'un stagiaire tout s'affiche correctement

_Si tu as lu cette description, pense a réagir avec un :eye:_
