### PR TITLE
COM-2851: fix 401 when delete account

### DIFF
--- a/src/screens/profile/Profile/index.tsx
+++ b/src/screens/profile/Profile/index.tsx
@@ -80,6 +80,11 @@ const Profile = ({ loggedUser, navigation }: ProfileProps) => {
     );
   };
 
+  const logout = () => {
+    setUserAccountDeletedModal(false);
+    signOut();
+  };
+
   return (
     <ScrollView style={commonStyles.container} contentContainerStyle={styles.container}>
       {!!loggedUser &&
@@ -151,7 +156,7 @@ const Profile = ({ loggedUser, navigation }: ProfileProps) => {
         setVisible={() => setDeletionConfirmationModal(false)}
         setConfirmationModal={() => setUserAccountDeletedModal(true)} />
       <UserAccountDeletedModal visible={userAccountDeletedModal} name={get(loggedUser, 'identity.firstname')}
-        logout={clearExpoTokenAndSignOut} />
+        logout={logout} />
     </ScrollView>
   );
 };


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] ~~Mes changements entrainent une incompatibilité avec l'ancienne version de l'api~~
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : mobile-formation / no role no company

- Cas d'usage : je n'ai plus de 401 quand je quitte la modale de suppression de compte

- Comment tester ? :
  - créer un compte et le supprimer => quand je ferme la 2nde modale, je suis redirigé vers la page d'authentification sans avoir d'erreur en console (le bug n'a l'air présent que sur iphone physique donc bien penser à le tester dessus)

_Si tu as lu cette description, pense a réagir avec un :eye:_
