### PR TITLE
COM-2879: change pdf name for completion certificate

### DIFF
--- a/src/screens/courses/CourseProfile/index.tsx
+++ b/src/screens/courses/CourseProfile/index.tsx
@@ -142,6 +142,13 @@ const CourseProfile = ({ route, navigation, userId, setStatusBarVisible, resetCo
     }
   };
 
+  const composeCourseName = (c) => {
+    const possiblyCompanyName = c.company ? `${c.company.name} - ` : '';
+    const possiblyMisc = c.misc ? ` - ${c.misc}` : '';
+
+    return possiblyCompanyName + c.subProgram.program.name + possiblyMisc;
+  };
+
   const downloadCompletionCertificate = async () => {
     if (!course) return;
 
@@ -150,7 +157,8 @@ const CourseProfile = ({ route, navigation, userId, setStatusBarVisible, resetCo
 
     const buffer = Buffer.from(data, 'base64');
     const pdf = buffer.toString('base64');
-    const fileUri = `${FileSystem.documentDirectory}${encodeURI('attestation')}.pdf`;
+    const pdfName = `attestation_${composeCourseName(course)}`;
+    const fileUri = `${FileSystem.documentDirectory}${encodeURI(pdfName)}.pdf`;
     await FileSystem.writeAsStringAsync(fileUri, pdf, { encoding: FileSystem.EncodingType.Base64 });
 
     if (Platform.OS === 'ios') {

--- a/src/screens/courses/CourseProfile/index.tsx
+++ b/src/screens/courses/CourseProfile/index.tsx
@@ -142,11 +142,10 @@ const CourseProfile = ({ route, navigation, userId, setStatusBarVisible, resetCo
     }
   };
 
-  const composeCourseName = (c) => {
-    const possiblyCompanyName = c.company ? `${c.company.name} - ` : '';
-    const possiblyMisc = c.misc ? ` - ${c.misc}` : '';
+  const getPdfName = (c) => {
+    const misc = c.misc ? `_${c.misc}` : '';
 
-    return possiblyCompanyName + c.subProgram.program.name + possiblyMisc;
+    return `attestation_${c.subProgram.program.name}${misc}`.replace(/ /g, '_').replace(/'/g, '_');
   };
 
   const downloadCompletionCertificate = async () => {
@@ -157,7 +156,7 @@ const CourseProfile = ({ route, navigation, userId, setStatusBarVisible, resetCo
 
     const buffer = Buffer.from(data, 'base64');
     const pdf = buffer.toString('base64');
-    const pdfName = `attestation_${composeCourseName(course)}`;
+    const pdfName = getPdfName(course);
     const fileUri = `${FileSystem.documentDirectory}${encodeURI(pdfName)}.pdf`;
     await FileSystem.writeAsStringAsync(fileUri, pdf, { encoding: FileSystem.EncodingType.Base64 });
 


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] ~~Mes changements entrainent une incompatibilité avec l'ancienne version de l'api~~
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : vendeur/client/mobile rof/coach/admin

- Cas d'usage : changement des noms des fichiers téléchargés suivants : convocation, feuilles d’emargement, attestation de fin de formation, facture, avoir

- Comment tester ? :
  - télécharger les docs suivants : 
   - convocation : convocation_nom de la formation (struct - nom programme - misc) (intra et inter)
   - feuilles d’emargement : feuilles d’emargement_nom de la formation (struct - nom programme - misc) (intra et inter)
   - attestation de fin de formation : attestation_nom de la formation (struct - nom programme - misc) (intra et inter) + mobile
   - facture : payeur - numero facture (ex : Onela-FACT-00023)
   - avoir :  payeur - numero avoir (ex : Onela-AV-00023)

_Si tu as lu cette description, pense a réagir avec un :eye:_