### PR TITLE
COM-2929: can scroll big flatlist

### DIFF
--- a/src/screens/courses/cardTemplates/OrderTheSequenceCard/index.tsx
+++ b/src/screens/courses/cardTemplates/OrderTheSequenceCard/index.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react';
-import { View, Text, ScrollView } from 'react-native';
+import { View, Text } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { connect } from 'react-redux';
 import shuffle from 'lodash/shuffle';
-import DraggableFlatList from 'react-native-draggable-flatlist';
+import { NestableScrollContainer, NestableDraggableFlatList } from 'react-native-draggable-flatlist';
 import { useNavigation } from '@react-navigation/native';
 import { footerColorsType, OrderedAnswerType, OrderTheSequenceType } from '../../../../types/CardType';
 import { StateType } from '../../../../types/store/StoreType';
@@ -98,19 +98,15 @@ const OrderTheSequenceCard = ({
   return (
     <SafeAreaView style={style.safeArea} edges={['top']}>
       <CardHeader />
-      <ScrollView alwaysBounceVertical={false} contentContainerStyle={style.container}
-        showsVerticalScrollIndicator={false}>
+      <NestableScrollContainer contentContainerStyle={style.container} showsVerticalScrollIndicator={false}>
         <Text style={[cardsStyle.question, style.question]}>{card.question}</Text>
-        <View>
-          <Text style={cardsStyle.informativeText}>
+        <Text style={cardsStyle.informativeText}>
             Classez les réponses dans le bon ordre : de la meilleure à la moins bonne
-          </Text>
-          <DraggableFlatList showsVerticalScrollIndicator={false} data={answers}
-            ListHeaderComponentStyle={style.questionContainer} onDragEnd={setAnswersArray}
-            keyExtractor={(_, answerIndex) => answerIndex.toString()} renderItem={renderItem}
-            activationDistance={SCROLL_SENSIBILITY_WHEN_SWIPE_ENABLED} />
-        </View>
-      </ScrollView>
+        </Text>
+        <NestableDraggableFlatList showsVerticalScrollIndicator={false} data={answers}
+          onDragEnd={setAnswersArray} keyExtractor={(_, answerIndex) => answerIndex.toString()} renderItem={renderItem}
+          activationDistance={SCROLL_SENSIBILITY_WHEN_SWIPE_ENABLED} style={style.flatListContainer}/>
+      </NestableScrollContainer>
       <View style={style.footerContainer}>
         {!isValidated && <FooterGradient /> }
         <QuizCardFooter isValidated={isValidated} isValid={isOrderedCorrectly} cardIndex={index}

--- a/src/screens/courses/cardTemplates/OrderTheSequenceCard/index.tsx
+++ b/src/screens/courses/cardTemplates/OrderTheSequenceCard/index.tsx
@@ -49,11 +49,6 @@ const OrderTheSequenceCard = ({
   });
   const navigation = useNavigation();
 
-  const [questionHeight, setQuestionHeight] = useState(0);
-  const [scrollViewHeight, setScrollViewHeight] = useState(0);
-  const [contentHeight, setContentHeight] = useState(0);
-  const [addMargin, setAddMargin] = useState(false);
-
   useEffect(() => {
     if (!isLoading && !isValidated) {
       const shuffledCards = shuffle(card.orderedAnswers
@@ -62,12 +57,6 @@ const OrderTheSequenceCard = ({
     }
     setIsRightSwipeEnabled(isValidated || false);
   }, [card, isValidated, isLoading, setIsRightSwipeEnabled]);
-
-  useEffect(() => {
-    if (questionHeight && scrollViewHeight && contentHeight) {
-      setAddMargin(questionHeight + scrollViewHeight > contentHeight);
-    }
-  }, [questionHeight, scrollViewHeight, contentHeight]);
 
   useEffect(() => {
     if (!isValidated) {
@@ -104,24 +93,20 @@ const OrderTheSequenceCard = ({
 
   if (isLoading) return null;
 
-  const style = styles(footerColors.background, addMargin);
+  const style = styles(footerColors.background);
 
   return (
     <SafeAreaView style={style.safeArea} edges={['top']}>
       <CardHeader />
-      <View style={style.container} onLayout={(event) => { setContentHeight(event.nativeEvent.layout.height); }}>
-        <Text style={[cardsStyle.question, style.question]}
-          onLayout={(event) => { setQuestionHeight(event.nativeEvent.layout.height); }}>
-          {card.question}
-        </Text>
-        <NestableScrollContainer showsVerticalScrollIndicator={false}
-          onLayout={(event) => { setScrollViewHeight(event.nativeEvent.layout.height); }}>
+      <Text style={[cardsStyle.question, style.question]}>{card.question}</Text>
+      <View style={style.container}>
+        <NestableScrollContainer showsVerticalScrollIndicator={false}>
           <Text style={cardsStyle.informativeText}>
             Classez les réponses dans le bon ordre : de la meilleure à la moins bonne
           </Text>
           <NestableDraggableFlatList showsVerticalScrollIndicator={false} data={answers} onDragEnd={setAnswersArray}
             keyExtractor={(_, answerIndex) => answerIndex.toString()} renderItem={renderItem}
-            activationDistance={SCROLL_SENSIBILITY_WHEN_SWIPE_ENABLED} style={style.flatListContainer}/>
+            activationDistance={SCROLL_SENSIBILITY_WHEN_SWIPE_ENABLED} />
         </NestableScrollContainer>
       </View>
       <View style={style.footerContainer}>

--- a/src/screens/courses/cardTemplates/OrderTheSequenceCard/index.tsx
+++ b/src/screens/courses/cardTemplates/OrderTheSequenceCard/index.tsx
@@ -49,6 +49,11 @@ const OrderTheSequenceCard = ({
   });
   const navigation = useNavigation();
 
+  const [questionHeight, setQuestionHeight] = useState(0);
+  const [scrollViewHeight, setScrollViewHeight] = useState(0);
+  const [contentHeight, setContentHeight] = useState(0);
+  const [addMargin, setAddMargin] = useState(false);
+
   useEffect(() => {
     if (!isLoading && !isValidated) {
       const shuffledCards = shuffle(card.orderedAnswers
@@ -57,6 +62,12 @@ const OrderTheSequenceCard = ({
     }
     setIsRightSwipeEnabled(isValidated || false);
   }, [card, isValidated, isLoading, setIsRightSwipeEnabled]);
+
+  useEffect(() => {
+    if (questionHeight && scrollViewHeight && contentHeight) {
+      setAddMargin(questionHeight + scrollViewHeight > contentHeight);
+    }
+  }, [questionHeight, scrollViewHeight, contentHeight]);
 
   useEffect(() => {
     if (!isValidated) {
@@ -93,20 +104,26 @@ const OrderTheSequenceCard = ({
 
   if (isLoading) return null;
 
-  const style = styles(footerColors.background);
+  const style = styles(footerColors.background, addMargin);
 
   return (
     <SafeAreaView style={style.safeArea} edges={['top']}>
       <CardHeader />
-      <NestableScrollContainer contentContainerStyle={style.container} showsVerticalScrollIndicator={false}>
-        <Text style={[cardsStyle.question, style.question]}>{card.question}</Text>
-        <Text style={cardsStyle.informativeText}>
-            Classez les réponses dans le bon ordre : de la meilleure à la moins bonne
+      <View style={style.container} onLayout={(event) => { setContentHeight(event.nativeEvent.layout.height); }}>
+        <Text style={[cardsStyle.question, style.question]}
+          onLayout={(event) => { setQuestionHeight(event.nativeEvent.layout.height); }}>
+          {card.question}
         </Text>
-        <NestableDraggableFlatList showsVerticalScrollIndicator={false} data={answers}
-          onDragEnd={setAnswersArray} keyExtractor={(_, answerIndex) => answerIndex.toString()} renderItem={renderItem}
-          activationDistance={SCROLL_SENSIBILITY_WHEN_SWIPE_ENABLED} style={style.flatListContainer}/>
-      </NestableScrollContainer>
+        <NestableScrollContainer showsVerticalScrollIndicator={false}
+          onLayout={(event) => { setScrollViewHeight(event.nativeEvent.layout.height); }}>
+          <Text style={cardsStyle.informativeText}>
+            Classez les réponses dans le bon ordre : de la meilleure à la moins bonne
+          </Text>
+          <NestableDraggableFlatList showsVerticalScrollIndicator={false} data={answers} onDragEnd={setAnswersArray}
+            keyExtractor={(_, answerIndex) => answerIndex.toString()} renderItem={renderItem}
+            activationDistance={SCROLL_SENSIBILITY_WHEN_SWIPE_ENABLED} style={style.flatListContainer}/>
+        </NestableScrollContainer>
+      </View>
       <View style={style.footerContainer}>
         {!isValidated && <FooterGradient /> }
         <QuizCardFooter isValidated={isValidated} isValid={isOrderedCorrectly} cardIndex={index}

--- a/src/screens/courses/cardTemplates/OrderTheSequenceCard/styles.ts
+++ b/src/screens/courses/cardTemplates/OrderTheSequenceCard/styles.ts
@@ -3,18 +3,18 @@ import { GREY } from '../../../../styles/colors';
 import { FIRA_SANS_REGULAR } from '../../../../styles/fonts';
 import { MARGIN } from '../../../../styles/metrics';
 
-const styles = (backgroundColor: string) => StyleSheet.create({
+const styles = (backgroundColor: string, addMargin: boolean) => StyleSheet.create({
   safeArea: {
     flex: 1,
     backgroundColor: GREY[100],
   },
   container: {
     marginHorizontal: MARGIN.LG,
-    flexGrow: 1,
+    flex: 1,
     justifyContent: 'space-between',
   },
   flatListContainer: {
-    marginBottom: '50%',
+    marginBottom: addMargin ? '30%' : '0%',
   },
   questionContainer: {
     justifyContent: 'space-between',
@@ -25,9 +25,6 @@ const styles = (backgroundColor: string) => StyleSheet.create({
   },
   footerContainer: {
     backgroundColor,
-    position: 'absolute',
-    bottom: 0,
-    width: '100%',
   },
 });
 

--- a/src/screens/courses/cardTemplates/OrderTheSequenceCard/styles.ts
+++ b/src/screens/courses/cardTemplates/OrderTheSequenceCard/styles.ts
@@ -3,7 +3,7 @@ import { GREY } from '../../../../styles/colors';
 import { FIRA_SANS_REGULAR } from '../../../../styles/fonts';
 import { MARGIN } from '../../../../styles/metrics';
 
-const styles = (backgroundColor: string, addMargin: boolean) => StyleSheet.create({
+const styles = (backgroundColor: string) => StyleSheet.create({
   safeArea: {
     flex: 1,
     backgroundColor: GREY[100],
@@ -11,10 +11,8 @@ const styles = (backgroundColor: string, addMargin: boolean) => StyleSheet.creat
   container: {
     marginHorizontal: MARGIN.LG,
     flex: 1,
-    justifyContent: 'space-between',
-  },
-  flatListContainer: {
-    marginBottom: addMargin ? '30%' : '0%',
+    justifyContent: 'flex-end',
+    marginBottom: MARGIN.SM,
   },
   questionContainer: {
     justifyContent: 'space-between',
@@ -22,6 +20,7 @@ const styles = (backgroundColor: string, addMargin: boolean) => StyleSheet.creat
   },
   question: {
     ...FIRA_SANS_REGULAR.MD,
+    marginHorizontal: MARGIN.LG,
   },
   footerContainer: {
     backgroundColor,

--- a/src/screens/courses/cardTemplates/OrderTheSequenceCard/styles.ts
+++ b/src/screens/courses/cardTemplates/OrderTheSequenceCard/styles.ts
@@ -1,7 +1,7 @@
 import { StyleSheet } from 'react-native';
 import { GREY } from '../../../../styles/colors';
 import { FIRA_SANS_REGULAR } from '../../../../styles/fonts';
-import { MARGIN, PADDING } from '../../../../styles/metrics';
+import { MARGIN } from '../../../../styles/metrics';
 
 const styles = (backgroundColor: string) => StyleSheet.create({
   safeArea: {
@@ -12,7 +12,9 @@ const styles = (backgroundColor: string) => StyleSheet.create({
     marginHorizontal: MARGIN.LG,
     flexGrow: 1,
     justifyContent: 'space-between',
-    paddingBottom: PADDING.XL,
+  },
+  flatListContainer: {
+    marginBottom: '50%',
   },
   questionContainer: {
     justifyContent: 'space-between',
@@ -23,6 +25,9 @@ const styles = (backgroundColor: string) => StyleSheet.create({
   },
   footerContainer: {
     backgroundColor,
+    position: 'absolute',
+    bottom: 0,
+    width: '100%',
   },
 });
 


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] ~~Mes changements entrainent une incompatibilité avec l'ancienne version de l'api~~
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : mobile-formation / tous

- Cas d'usage : sur les cartes mettre dans l'ordre quand les propositions sont très longue je peux scroller

⚠️ en utilisant NestableScrollContainer, NestableDraggableFlatList je n'arrive plus à avoir les proposition alignées en bas de l'écran comme c'était le cas avant, le space-between ne semble pas fonctionner, si vous avez une solution je suis preneur

- Comment tester ? :
  - tester des cartes mettre dans l'ordre avec des propositions courtes (scroll non nécessaire) et longues (scroll nécessaire) 

_Si tu as lu cette description, pense a réagir avec un :eye:_
