### PR TITLE
COM-2983: can't show activity on non-elearning step

### DIFF
--- a/src/components/steps/LiveCell/index.tsx
+++ b/src/components/steps/LiveCell/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { View, TouchableOpacity } from 'react-native';
+import { Feather } from '@expo/vector-icons';
 import { SlotType } from '../../../types/CourseTypes';
 import { LiveStepType } from '../../../types/StepTypes';
 import { ascendingSort } from '../../../core/helpers/dates/utils';
@@ -7,26 +8,20 @@ import CalendarIcon from '../../CalendarIcon';
 import { ICON } from '../../../styles/metrics';
 import { GREY } from '../../../styles/colors';
 import StepCellTitle from '../StepCellTitle';
-import ActivityList from '../../activities/ActivityList';
 import LiveCellInfoModal from '../LiveCellInfoModal';
-import FeatherButton from '../../icons/FeatherButton';
 import styles from './styles';
 
 type LiveCellProps = {
   step: LiveStepType,
   slots?: SlotType[],
   index: number,
-  profileId: string,
 }
 
-const LiveCell = ({ step, slots = [], index, profileId }: LiveCellProps) => {
+const LiveCell = ({ step, slots = [], index }: LiveCellProps) => {
   const [isModalVisible, setIsModalVisible] = useState(false);
-  const [isOpen, setIsOpen] = useState<boolean>(false);
   const [stepSlots, setStepSlots] = useState<SlotType[]>([]);
   const [dates, setDates] = useState<Date[]>([]);
   const [modalTitle, setModalTitle] = useState('');
-
-  const onPressChevron = () => { setIsOpen(prevState => !prevState); };
 
   useEffect(() => { setModalTitle(`Etape ${index + 1} - ${step.name}`); }, [step, index]);
 
@@ -46,22 +41,13 @@ const LiveCell = ({ step, slots = [], index, profileId }: LiveCellProps) => {
     <>
       <LiveCellInfoModal title={modalTitle} stepSlots={stepSlots} visible={isModalVisible}
         onRequestClose={closeModal} />
-      <TouchableOpacity style={[styles.container, styles.upperContainer, isOpen && styles.openedContainer]}
-        onPress={onPressChevron} disabled={!step.activities?.length}>
-        <TouchableOpacity onPress={openModal}>
-          <CalendarIcon slots={dates} progress={step.progress.live} />
-        </TouchableOpacity>
+      <TouchableOpacity style={[styles.container, styles.upperContainer]} onPress={openModal}>
+        <CalendarIcon slots={dates} progress={step.progress.live} />
         <StepCellTitle index={index} name={step.name} type={step.type} />
         <View style={styles.iconContainer}>
-          <FeatherButton name='info' onPress={openModal} size={ICON.LG} color={GREY[500]}
-            style={styles.infoButtonContainer} />
-          {!!step.activities?.length && <FeatherButton name={isOpen ? 'chevron-up' : 'chevron-down' }
-            onPress={onPressChevron} size={ICON.MD} color={GREY[500]} style={styles.iconButtonContainer} />}
+          <Feather name='info' size={ICON.LG} color={GREY[500]} style={styles.infoButtonContainer} />
         </View>
       </TouchableOpacity>
-      {isOpen && <View style={[styles.container, styles.openedContainer]}>
-        <ActivityList activities={step.activities} profileId={profileId} />
-      </View>}
     </>
   );
 };

--- a/src/screens/courses/CourseProfile/index.tsx
+++ b/src/screens/courses/CourseProfile/index.tsx
@@ -60,7 +60,7 @@ StackScreenProps<RootBottomTabParamList>
 
 const renderStepCell = ({ item, index }, course, route) => {
   if ([ON_SITE, REMOTE].includes(item.type)) {
-    return <LiveCell step={item} slots={course?.slots} index={index} profileId={route.params.courseId} />;
+    return <LiveCell step={item} slots={course?.slots} index={index} />;
   }
 
   if (item.type === E_LEARNING) {


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone
- [x] J'ai testé sur android
- [x] J'ai testé sur tablette 

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] ~~Mes changements entrainent une incompatibilité avec l'ancienne version de l'api~~
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : mobile-formation utilisateur

- Cas d'usage : 
  - la progression d'une l'étape présentielle/distancielle sur l'app mobile correspond bien à son avancement dans le temps uniquement 
  - quand je clique sur une cellule d'étape présentielle ou distancielle ça m'affiche le détail des créneaux

- Comment tester ? :

_Si tu as lu cette description, pense a réagir avec un :eye:_
