### PR TITLE
Com 2975

### DIFF
--- a/src/api/courses.ts
+++ b/src/api/courses.ts
@@ -8,14 +8,14 @@ import {
   CourseResponseType,
   PdfResponseType,
 } from '../types/AxiosTypes';
-import { MOBILE, OPERATION, BLENDED } from '../core/data/constants';
+import { MOBILE, OPERATIONS, BLENDED } from '../core/data/constants';
 
 export default {
   getTrainerCourses: async (userId: string): Promise<BlendedCourseType[]> => {
     const baseURL = await Environment.getBaseUrl();
     const response: AxiosResponse<BlendedCourseListResponseType> = await axiosLogged.get(
       `${baseURL}/courses`,
-      { params: { action: OPERATION, origin: MOBILE, format: BLENDED, trainer: userId } }
+      { params: { action: OPERATIONS, origin: MOBILE, format: BLENDED, trainer: userId } }
     );
 
     return response.data.data.courses;

--- a/src/api/courses.ts
+++ b/src/api/courses.ts
@@ -1,21 +1,27 @@
 import { AxiosResponse } from 'axios';
 import axiosLogged from './axios/logged';
 import Environment from '../../environment';
-import { BlendedCourseType, CourseType } from '../types/CourseTypes';
+import { CourseType, BlendedCourseType } from '../types/CourseTypes';
 import {
   CourseListResponseType,
   BlendedCourseListResponseType,
   CourseResponseType,
   PdfResponseType,
 } from '../types/AxiosTypes';
-import { MOBILE, OPERATIONS, BLENDED } from '../core/data/constants';
+import { MOBILE } from '../core/data/constants';
+
+type getCourseListType = {
+  action: string,
+  format?: string,
+  trainer?: string
+}
 
 export default {
-  getTrainerCourses: async (userId: string): Promise<BlendedCourseType[]> => {
+  getCourseList: async ({ action, format, trainer }: getCourseListType): Promise<BlendedCourseType[]> => {
     const baseURL = await Environment.getBaseUrl();
     const response: AxiosResponse<BlendedCourseListResponseType> = await axiosLogged.get(
       `${baseURL}/courses`,
-      { params: { action: OPERATIONS, origin: MOBILE, format: BLENDED, trainer: userId } }
+      { params: { action, format, trainer, origin: MOBILE } }
     );
 
     return response.data.data.courses;

--- a/src/api/courses.ts
+++ b/src/api/courses.ts
@@ -10,18 +10,18 @@ import {
 } from '../types/AxiosTypes';
 import { MOBILE } from '../core/data/constants';
 
-type getCourseListType = {
+type GetCourseListType = {
   action: string,
   format?: string,
   trainer?: string
 }
 
 export default {
-  getCourseList: async ({ action, format, trainer }: getCourseListType): Promise<BlendedCourseType[]> => {
+  getCourseList: async (params: GetCourseListType): Promise<BlendedCourseType[]> => {
     const baseURL = await Environment.getBaseUrl();
     const response: AxiosResponse<BlendedCourseListResponseType> = await axiosLogged.get(
       `${baseURL}/courses`,
-      { params: { action, format, trainer, origin: MOBILE } }
+      { params: { ...params, origin: MOBILE } }
     );
 
     return response.data.data.courses;

--- a/src/api/courses.ts
+++ b/src/api/courses.ts
@@ -1,14 +1,19 @@
 import { AxiosResponse } from 'axios';
 import axiosLogged from './axios/logged';
 import Environment from '../../environment';
-import { CourseType } from '../types/CourseTypes';
-import { CourseListResponseType, CourseResponseType, PdfResponseType } from '../types/AxiosTypes';
+import { BlendedCourseType, CourseType } from '../types/CourseTypes';
+import {
+  CourseListResponseType,
+  BlendedCourseListResponseType,
+  CourseResponseType,
+  PdfResponseType,
+} from '../types/AxiosTypes';
 import { MOBILE, OPERATION, BLENDED } from '../core/data/constants';
 
 export default {
-  getTrainerCourses: async (userId: string): Promise<CourseType[]> => {
+  getTrainerCourses: async (userId: string): Promise<BlendedCourseType[]> => {
     const baseURL = await Environment.getBaseUrl();
-    const response: AxiosResponse<CourseListResponseType> = await axiosLogged.get(
+    const response: AxiosResponse<BlendedCourseListResponseType> = await axiosLogged.get(
       `${baseURL}/courses`,
       { params: { action: OPERATION, origin: MOBILE, format: BLENDED, trainer: userId } }
     );

--- a/src/api/courses.ts
+++ b/src/api/courses.ts
@@ -3,9 +3,18 @@ import axiosLogged from './axios/logged';
 import Environment from '../../environment';
 import { CourseType } from '../types/CourseTypes';
 import { CourseListResponseType, CourseResponseType, PdfResponseType } from '../types/AxiosTypes';
-import { MOBILE } from '../core/data/constants';
+import { MOBILE, OPERATION, BLENDED } from '../core/data/constants';
 
 export default {
+  getTrainerCourses: async (userId: string): Promise<CourseType[]> => {
+    const baseURL = await Environment.getBaseUrl();
+    const response: AxiosResponse<CourseListResponseType> = await axiosLogged.get(
+      `${baseURL}/courses`,
+      { params: { action: OPERATION, origin: MOBILE, format: BLENDED, trainer: userId } }
+    );
+
+    return response.data.data.courses;
+  },
   getUserCourses: async (): Promise<CourseType[]> => {
     const baseURL = await Environment.getBaseUrl();
     const response: AxiosResponse<CourseListResponseType> = await axiosLogged.get(`${baseURL}/courses/user`);

--- a/src/components/ProgramCell/index.tsx
+++ b/src/components/ProgramCell/index.tsx
@@ -43,7 +43,7 @@ const ProgramCell = ({ program, theoreticalHours, progress = null, misc = '', on
       <Text style={styles.title} lineBreakMode={'tail'} numberOfLines={2}>
         {programName}{misc ? ` - ${misc}` : ''}
       </Text>
-      <Text style={styles.description} lineBreakMode={'tail'} numberOfLines={4}>{programDescription}</Text>
+      <Text style={styles.description} lineBreakMode={'tail'} numberOfLines={3}>{programDescription}</Text>
       {!!theoreticalHours &&
         <View>
           <Text style={styles.eLearning}>E-LEARNING</Text>

--- a/src/components/ProgramCell/index.tsx
+++ b/src/components/ProgramCell/index.tsx
@@ -43,7 +43,7 @@ const ProgramCell = ({ program, theoreticalHours, progress = null, misc = '', on
       <Text style={styles.title} lineBreakMode={'tail'} numberOfLines={2}>
         {programName}{misc ? ` - ${misc}` : ''}
       </Text>
-      <Text style={styles.description} lineBreakMode={'tail'} numberOfLines={3}>{programDescription}</Text>
+      <Text style={styles.description} lineBreakMode={'tail'} numberOfLines={4}>{programDescription}</Text>
       {!!theoreticalHours &&
         <View>
           <Text style={styles.eLearning}>E-LEARNING</Text>

--- a/src/components/ProgramCell/styles.ts
+++ b/src/components/ProgramCell/styles.ts
@@ -4,7 +4,7 @@ import { BORDER_RADIUS, PADDING, PROGRAM_CELL_WIDTH, BORDER_WIDTH, ICON, MARGIN 
 import { FIRA_SANS_REGULAR, FIRA_SANS_BOLD } from '../../styles/fonts';
 
 const imageHeight = 128;
-const containerHeight = 304;
+const containerHeight = 322;
 const styles = StyleSheet.create({
   courseContainer: {
     borderRadius: BORDER_RADIUS.SM,

--- a/src/core/data/constants.ts
+++ b/src/core/data/constants.ts
@@ -6,6 +6,8 @@ export const PRODUCTION = 'production';
 
 // COURSES
 export const STRICTLY_E_LEARNING = 'strictly_e_learning';
+export const BLENDED = 'blended';
+export const OPERATION = 'operation';
 
 // STEPS
 export const ON_SITE = 'on_site';

--- a/src/core/data/constants.ts
+++ b/src/core/data/constants.ts
@@ -7,7 +7,7 @@ export const PRODUCTION = 'production';
 // COURSES
 export const STRICTLY_E_LEARNING = 'strictly_e_learning';
 export const BLENDED = 'blended';
-export const OPERATION = 'operation';
+export const OPERATIONS = 'operations';
 
 // STEPS
 export const ON_SITE = 'on_site';

--- a/src/core/helpers/dates/companiDates.ts
+++ b/src/core/helpers/dates/companiDates.ts
@@ -16,6 +16,7 @@ type CompaniDateType = {
   isSame: (miscTypeOtherDate: DateTypes, unit : DateTimeUnit) => boolean,
   isBefore: (date: DateTypes) => boolean,
   isAfter: (date: DateTypes) => boolean,
+  isSameOrAfter: (date: DateTypes) => boolean,
   isSameOrBefore: (date: DateTypes) => boolean,
   startOf: (unit: DateTimeUnit) => CompaniDateType,
   endOf: (unit: DateTimeUnit) => CompaniDateType,
@@ -67,6 +68,12 @@ const CompaniDateFactory = (inputDate: DateTime): CompaniDateType => {
       const otherDate = _formatMiscToCompaniDate(miscTypeOtherDate);
 
       return _date > otherDate;
+    },
+
+    isSameOrAfter(miscTypeOtherDate : DateTypes) {
+      const otherDate = _formatMiscToCompaniDate(miscTypeOtherDate);
+
+      return _date >= otherDate;
     },
 
     isSameOrBefore(miscTypeOtherDate : DateTypes) {

--- a/src/screens/courses/list/LearnerCourses/index.tsx
+++ b/src/screens/courses/list/LearnerCourses/index.tsx
@@ -147,27 +147,27 @@ const LearnerCourses = ({ setIsCourse, navigation, loggedUserId }: LearnerCourse
         <Text style={commonStyles.title} testID='header'>Mes formations</Text>
         {!!nextSteps.length &&
           <View style={styles.nextSteps}>
-            <CoursesSection items={nextSteps} title='Mes prochains rendez-vous' countStyle={styles.nextEventsCount}
+            <CoursesSection items={nextSteps} title='Mes prochains rendez-vous' countStyle={styles.pinkCount}
               renderItem={renderNextStepsItem} type={EVENT_SECTION} />
           </View>
         }
-        <ImageBackground imageStyle={styles.onGoingAndDraftBackground} style={styles.sectionContainer}
+        <ImageBackground imageStyle={styles.leftBackground} style={styles.sectionContainer}
           source={require('../../../../../assets/images/yellow_section_background.png')}>
           <CoursesSection items={courses.onGoing} title='Mes formations en cours' renderItem={renderCourseItem}
-            countStyle={styles.onGoingCoursesCount} showCatalogButton={!courses.onGoing.length} />
+            countStyle={styles.yellowCount} showCatalogButton={!courses.onGoing.length} />
         </ImageBackground>
         {!!courses.achieved.length &&
-          <ImageBackground imageStyle={styles.achievedBackground} style={styles.sectionContainer}
+          <ImageBackground imageStyle={styles.rightBackground} style={styles.sectionContainer}
             source={require('../../../../../assets/images/green_section_background.png')}>
             <CoursesSection items={courses.achieved} title='Mes formations terminées' renderItem={renderCourseItem}
-              countStyle={styles.achievedCoursesCount} />
+              countStyle={styles.greenCount} />
           </ImageBackground>
         }
         {!!elearningDraftSubPrograms.length &&
-          <ImageBackground imageStyle={styles.onGoingAndDraftBackground} style={styles.sectionContainer}
+          <ImageBackground imageStyle={styles.leftBackground} style={styles.sectionContainer}
             source={require('../../../../../assets/images/purple_section_background.png')}>
             <CoursesSection items={elearningDraftSubPrograms} title='Mes formations à tester'
-              countStyle={styles.subProgramsCount} renderItem={renderSubProgramItem} />
+              countStyle={styles.purpleCount} renderItem={renderSubProgramItem} />
           </ImageBackground>
         }
         <View style={styles.footer}>

--- a/src/screens/courses/list/TrainerCourses/index.tsx
+++ b/src/screens/courses/list/TrainerCourses/index.tsx
@@ -10,11 +10,13 @@ import Courses from '../../../../api/courses';
 import CoursesSection from '../../../../components/CoursesSection';
 import ProgramCell from '../../../../components/ProgramCell';
 import companiDates from '../../../../core/helpers/dates/companiDates';
+import { getTheoreticalHours } from '../../../../core/helpers/utils';
 import { BlendedCourseType } from '../../../../types/CourseTypes';
 import { RootBottomTabParamList, RootStackParamList } from '../../../../types/NavigationType';
 import { getLoggedUserId } from '../../../../store/main/selectors';
 import commonStyles from '../../../../styles/common';
 import styles from '../styles';
+import { E_LEARNING } from '../../../../core/data/constants';
 
 const CategoriesStyleList = [
   {
@@ -57,8 +59,10 @@ const formatCoursesDiplayContents = (courses: BlendedCourseType[]) => [
   { ...CategoriesStyleList[2], courses: courses.filter(c => isCompleted(c)) },
 ];
 
+const getElearningSteps = steps => steps.filter(step => step.type === E_LEARNING);
+
 const renderCourseItem = course => <ProgramCell onPress={() => {}} program={get(course, 'subProgram.program') || {}}
-  misc={course.misc} theoreticalHours={0} />;
+  misc={course.misc} theoreticalHours={getTheoreticalHours(getElearningSteps(get(course, 'subProgram.steps')))} />;
 
 interface TrainerCoursesProps extends CompositeScreenProps<
 StackScreenProps<RootBottomTabParamList>,

--- a/src/screens/courses/list/TrainerCourses/index.tsx
+++ b/src/screens/courses/list/TrainerCourses/index.tsx
@@ -1,19 +1,58 @@
 import 'array-flat-polyfill';
+import { useState, useEffect, useCallback } from 'react';
 import { Text, View, ScrollView, Image } from 'react-native';
+import { connect } from 'react-redux';
+import { useIsFocused, CompositeScreenProps } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { StackScreenProps } from '@react-navigation/stack';
+import { getLoggedUserId } from '../../../../store/main/selectors';
+import Courses from '../../../../api/courses';
 import commonStyles from '../../../../styles/common';
+import { CourseType } from '../../../../types/CourseTypes';
+import { RootBottomTabParamList, RootStackParamList } from '../../../../types/NavigationType';
 import styles from '../styles';
 
-const TrainerCourses = () => (
-  <SafeAreaView style={commonStyles.container} edges={['top']}>
-    <ScrollView contentContainerStyle={styles.container}>
-      <Text style={commonStyles.title} testID='header'>Espace intervenant</Text>
-      <View style={styles.footer}>
-        <Image style={styles.elipse} source={require('../../../../../assets/images/log_out_background.png')} />
-        <Image source={require('../../../../../assets/images/pa_aidant_balade_bleu.png')} style={styles.fellow} />
-      </View>
-    </ScrollView>
-  </SafeAreaView>
-);
+interface TrainerCoursesProps extends CompositeScreenProps<
+StackScreenProps<RootBottomTabParamList>,
+StackScreenProps<RootStackParamList>
+> {
+  loggedUserId: string | null,
+}
 
-export default TrainerCourses;
+const TrainerCourses = ({ loggedUserId }: TrainerCoursesProps) => {
+  const [courses, setCourses] = useState<CourseType[]>([]);
+  const isFocused = useIsFocused();
+
+  const getCourses = useCallback(async () => {
+    try {
+      if (loggedUserId) {
+        const fetchedCourses: CourseType[] = await Courses.getTrainerCourses(loggedUserId);
+        setCourses(fetchedCourses);
+      }
+    } catch (e: any) {
+      console.error(e);
+      // dispatch({ type: RESET_COURSES });
+    }
+  }, [loggedUserId]);
+
+  useEffect(() => {
+    if (isFocused) getCourses();
+  }, [isFocused, getCourses, loggedUserId]);
+
+  return (
+    <SafeAreaView style={commonStyles.container} edges={['top']}>
+      <Text>{JSON.stringify(courses)}</Text>
+      <ScrollView contentContainerStyle={styles.container}>
+        <Text style={commonStyles.title} testID='header'>Espace intervenant</Text>
+        <View style={styles.footer}>
+          <Image style={styles.elipse} source={require('../../../../../assets/images/log_out_background.png')} />
+          <Image source={require('../../../../../assets/images/pa_aidant_balade_bleu.png')} style={styles.fellow} />
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const mapStateToProps = state => ({ loggedUserId: getLoggedUserId(state) });
+
+export default connect(mapStateToProps)(TrainerCourses);

--- a/src/screens/courses/list/TrainerCourses/index.tsx
+++ b/src/screens/courses/list/TrainerCourses/index.tsx
@@ -9,64 +9,45 @@ import get from 'lodash/get';
 import Courses from '../../../../api/courses';
 import CoursesSection from '../../../../components/CoursesSection';
 import ProgramCell from '../../../../components/ProgramCell';
-import companiDates from '../../../../core/helpers/dates/companiDates';
 import { getTheoreticalHours } from '../../../../core/helpers/utils';
 import { BlendedCourseType } from '../../../../types/CourseTypes';
 import { RootBottomTabParamList, RootStackParamList } from '../../../../types/NavigationType';
 import { getLoggedUserId } from '../../../../store/main/selectors';
 import commonStyles from '../../../../styles/common';
 import styles from '../styles';
-import { E_LEARNING } from '../../../../core/data/constants';
-
-const CategoriesStyleList = [
-  {
-    title: 'En cours',
-    source: require('../../../../../assets/images/yellow_section_background.png'),
-    imageStyle: styles.leftBackground,
-    countStyle: styles.yellowCount,
-  },
-  {
-    title: 'À venir',
-    source: require('../../../../../assets/images/purple_section_background.png'),
-    imageStyle: styles.rightBackground,
-    countStyle: styles.purpleCount,
-  },
-  {
-    title: 'Terminées',
-    source: require('../../../../../assets/images/green_section_background.png'),
-    imageStyle: styles.leftBackground,
-    countStyle: styles.greenCount,
-  },
-];
-
-const noSlot = (course: BlendedCourseType) => !course.slots.length && !course.slotsToPlan.length;
-const isForthcoming = (course: BlendedCourseType) => {
-  const noSlotPlannedAndSlotToPlan = !course.slots.length && course.slotsToPlan.length;
-  const noSlotHasBeenStarted = !course.slots.some(slot => companiDates().isSameOrAfter(slot.startDate));
-
-  return noSlotPlannedAndSlotToPlan || noSlotHasBeenStarted;
-};
-const isInProgress = (course: BlendedCourseType) => {
-  const notEverySlotsHappened = course.slots.some(slot => companiDates().isSameOrBefore(slot.endDate));
-  const slotsToPlan = course.slotsToPlan.length;
-
-  return !isForthcoming(course) && (notEverySlotsHappened || slotsToPlan);
-};
-const isCompleted = (course: BlendedCourseType) => !noSlot(course) && !isForthcoming(course) && !isInProgress(course);
+import { isInProgress, isForthcoming, isCompleted, getElearningSteps } from '../helper';
 
 const formatCoursesDiplayContents = (courses: BlendedCourseType[]) => {
   const coursesInProgress = courses.filter(c => isInProgress(c));
   const coursesForthcoming = courses.filter(c => isForthcoming(c));
   const coursesCompleted = courses.filter(c => isCompleted(c));
 
-  return [
-    ...(coursesInProgress.length ? [{ ...CategoriesStyleList[0], courses: coursesInProgress }] : []),
-    ...(coursesForthcoming.length ? [{ ...CategoriesStyleList[1], courses: coursesForthcoming }] : []),
-    ...(coursesCompleted.length ? [{ ...CategoriesStyleList[2], courses: coursesCompleted }] : []),
+  const contents = [
+    {
+      title: 'En cours',
+      source: require('../../../../../assets/images/yellow_section_background.png'),
+      imageStyle: styles.leftBackground,
+      countStyle: styles.yellowCount,
+      courses: coursesInProgress,
+    },
+    {
+      title: 'À venir',
+      source: require('../../../../../assets/images/purple_section_background.png'),
+      imageStyle: styles.rightBackground,
+      countStyle: styles.purpleCount,
+      courses: coursesForthcoming,
+    },
+    {
+      title: 'Terminées',
+      source: require('../../../../../assets/images/green_section_background.png'),
+      imageStyle: styles.leftBackground,
+      countStyle: styles.greenCount,
+      courses: coursesCompleted,
+    },
   ];
-};
 
-const getElearningSteps = steps => steps.filter(step => step.type === E_LEARNING);
+  return contents.filter(section => section.courses.length);
+};
 
 const renderCourseItem = course => <ProgramCell onPress={() => {}} program={get(course, 'subProgram.program') || {}}
   misc={course.misc} theoreticalHours={getTheoreticalHours(getElearningSteps(get(course, 'subProgram.steps')))} />;

--- a/src/screens/courses/list/TrainerCourses/index.tsx
+++ b/src/screens/courses/list/TrainerCourses/index.tsx
@@ -39,11 +39,12 @@ const CategoriesStyleList = [
   },
 ];
 
+const noSlot = (course: BlendedCourseType) => !course.slots.length && !course.slotsToPlan.length;
 const isForthcoming = (course: BlendedCourseType) => {
-  const noSlotPlanned = !course.slots.length && course.slotsToPlan.length;
+  const noSlotPlannedAndSlotToPlan = !course.slots.length && course.slotsToPlan.length;
   const noSlotHasBeenStarted = !course.slots.some(slot => companiDates().isSameOrAfter(slot.startDate));
 
-  return noSlotPlanned || noSlotHasBeenStarted;
+  return noSlotPlannedAndSlotToPlan || noSlotHasBeenStarted;
 };
 const isInProgress = (course: BlendedCourseType) => {
   const notEverySlotsHappened = course.slots.some(slot => companiDates().isSameOrBefore(slot.endDate));
@@ -51,7 +52,7 @@ const isInProgress = (course: BlendedCourseType) => {
 
   return !isForthcoming(course) && (notEverySlotsHappened || slotsToPlan);
 };
-const isCompleted = (course: BlendedCourseType) => !isForthcoming(course) && !isInProgress(course);
+const isCompleted = (course: BlendedCourseType) => !noSlot(course) && !isForthcoming(course) && !isInProgress(course);
 
 const formatCoursesDiplayContents = (courses: BlendedCourseType[]) => {
   const coursesInProgress = courses.filter(c => isInProgress(c));

--- a/src/screens/courses/list/TrainerCourses/index.tsx
+++ b/src/screens/courses/list/TrainerCourses/index.tsx
@@ -53,11 +53,17 @@ const isInProgress = (course: BlendedCourseType) => {
 };
 const isCompleted = (course: BlendedCourseType) => !isForthcoming(course) && !isInProgress(course);
 
-const formatCoursesDiplayContents = (courses: BlendedCourseType[]) => [
-  { ...CategoriesStyleList[0], courses: courses.filter(c => isInProgress(c)) },
-  { ...CategoriesStyleList[1], courses: courses.filter(c => isForthcoming(c)) },
-  { ...CategoriesStyleList[2], courses: courses.filter(c => isCompleted(c)) },
-];
+const formatCoursesDiplayContents = (courses: BlendedCourseType[]) => {
+  const coursesInProgress = courses.filter(c => isInProgress(c));
+  const coursesForthcoming = courses.filter(c => isForthcoming(c));
+  const coursesCompleted = courses.filter(c => isCompleted(c));
+
+  return [
+    ...(coursesInProgress.length ? [{ ...CategoriesStyleList[0], courses: coursesInProgress }] : []),
+    ...(coursesForthcoming.length ? [{ ...CategoriesStyleList[1], courses: coursesForthcoming }] : []),
+    ...(coursesCompleted.length ? [{ ...CategoriesStyleList[2], courses: coursesCompleted }] : []),
+  ];
+};
 
 const getElearningSteps = steps => steps.filter(step => step.type === E_LEARNING);
 

--- a/src/screens/courses/list/TrainerCourses/index.tsx
+++ b/src/screens/courses/list/TrainerCourses/index.tsx
@@ -16,6 +16,7 @@ import { getLoggedUserId } from '../../../../store/main/selectors';
 import commonStyles from '../../../../styles/common';
 import styles from '../styles';
 import { isInProgress, isForthcoming, isCompleted, getElearningSteps } from '../helper';
+import { BLENDED, OPERATIONS } from '../../../../core/data/constants';
 
 const formatCoursesDiplayContents = (courses: BlendedCourseType[]) => {
   const coursesInProgress = courses.filter(c => isInProgress(c));
@@ -66,8 +67,12 @@ const TrainerCourses = ({ loggedUserId }: TrainerCoursesProps) => {
   const getCourses = useCallback(async () => {
     try {
       if (loggedUserId) {
-        const fetchedCourses: BlendedCourseType[] = await Courses.getTrainerCourses(loggedUserId);
-        const formatedCourses = formatCoursesDiplayContents(fetchedCourses);
+        const fetchedCourses = await Courses.getCourseList({
+          action: OPERATIONS,
+          format: BLENDED,
+          trainer: loggedUserId,
+        });
+        const formatedCourses: any[] = formatCoursesDiplayContents(fetchedCourses);
         setCoursesDisplayContent(formatedCourses);
       }
     } catch (e: any) {
@@ -84,7 +89,7 @@ const TrainerCourses = ({ loggedUserId }: TrainerCoursesProps) => {
     <SafeAreaView style={commonStyles.container} edges={['top']}>
       <ScrollView contentContainerStyle={styles.container}>
         <Text style={commonStyles.title} testID='header'>Espace intervenant</Text>
-        { coursesDisplayContent.map(content => (
+        {coursesDisplayContent.map(content => (
           <ImageBackground imageStyle={content.imageStyle} style={styles.sectionContainer}
             key={content.title} source={content.source}>
             <CoursesSection items={content.courses} title={content.title}

--- a/src/screens/courses/list/TrainerCourses/index.tsx
+++ b/src/screens/courses/list/TrainerCourses/index.tsx
@@ -14,16 +14,17 @@ import { BlendedCourseType } from '../../../../types/CourseTypes';
 import { RootBottomTabParamList, RootStackParamList } from '../../../../types/NavigationType';
 import { getLoggedUserId } from '../../../../store/main/selectors';
 import commonStyles from '../../../../styles/common';
+import { BLENDED, OPERATIONS } from '../../../../core/data/constants';
 import styles from '../styles';
 import { isInProgress, isForthcoming, isCompleted, getElearningSteps } from '../helper';
-import { BLENDED, OPERATIONS } from '../../../../core/data/constants';
+import { CourseDisplayType } from '../types';
 
-const formatCoursesDiplayContents = (courses: BlendedCourseType[]) => {
+const formatCoursesDiplaysContent = (courses: BlendedCourseType[]) => {
   const coursesInProgress = courses.filter(c => isInProgress(c));
-  const coursesForthcoming = courses.filter(c => isForthcoming(c));
-  const coursesCompleted = courses.filter(c => isCompleted(c));
+  const forthcomingCourses = courses.filter(c => isForthcoming(c));
+  const completedCourses = courses.filter(c => isCompleted(c));
 
-  const contents = [
+  const contents: CourseDisplayType[] = [
     {
       title: 'En cours',
       source: require('../../../../../assets/images/yellow_section_background.png'),
@@ -36,22 +37,23 @@ const formatCoursesDiplayContents = (courses: BlendedCourseType[]) => {
       source: require('../../../../../assets/images/purple_section_background.png'),
       imageStyle: styles.rightBackground,
       countStyle: styles.purpleCount,
-      courses: coursesForthcoming,
+      courses: forthcomingCourses,
     },
     {
       title: 'Terminées',
       source: require('../../../../../assets/images/green_section_background.png'),
       imageStyle: styles.leftBackground,
       countStyle: styles.greenCount,
-      courses: coursesCompleted,
+      courses: completedCourses,
     },
   ];
 
   return contents.filter(section => section.courses.length);
 };
 
-const renderCourseItem = course => <ProgramCell onPress={() => {}} program={get(course, 'subProgram.program') || {}}
-  misc={course.misc} theoreticalHours={getTheoreticalHours(getElearningSteps(get(course, 'subProgram.steps')))} />;
+const renderCourseItem = (course: BlendedCourseType) => <ProgramCell program={get(course, 'subProgram.program') || {}}
+  misc={course.misc} theoreticalHours={getTheoreticalHours(getElearningSteps(get(course, 'subProgram.steps')))}
+  onPress={() => {}} />;
 
 interface TrainerCoursesProps extends CompositeScreenProps<
 StackScreenProps<RootBottomTabParamList>,
@@ -61,7 +63,7 @@ StackScreenProps<RootStackParamList>
 }
 
 const TrainerCourses = ({ loggedUserId }: TrainerCoursesProps) => {
-  const [coursesDisplayContent, setCoursesDisplayContent] = useState<any[]>([]);
+  const [coursesDisplays, setCoursesDisplays] = useState<CourseDisplayType[]>([]);
   const isFocused = useIsFocused();
 
   const getCourses = useCallback(async () => {
@@ -72,12 +74,12 @@ const TrainerCourses = ({ loggedUserId }: TrainerCoursesProps) => {
           format: BLENDED,
           trainer: loggedUserId,
         });
-        const formatedCourses: any[] = formatCoursesDiplayContents(fetchedCourses);
-        setCoursesDisplayContent(formatedCourses);
+        const formatedCourses = formatCoursesDiplaysContent(fetchedCourses);
+        setCoursesDisplays(formatedCourses);
       }
     } catch (e: any) {
       console.error(e);
-      setCoursesDisplayContent([]);
+      setCoursesDisplays([]);
     }
   }, [loggedUserId]);
 
@@ -89,7 +91,7 @@ const TrainerCourses = ({ loggedUserId }: TrainerCoursesProps) => {
     <SafeAreaView style={commonStyles.container} edges={['top']}>
       <ScrollView contentContainerStyle={styles.container}>
         <Text style={commonStyles.title} testID='header'>Espace intervenant</Text>
-        {coursesDisplayContent.map(content => (
+        {coursesDisplays.map(content => (
           <ImageBackground imageStyle={content.imageStyle} style={styles.sectionContainer}
             key={content.title} source={content.source}>
             <CoursesSection items={content.courses} title={content.title}

--- a/src/screens/courses/list/helper.ts
+++ b/src/screens/courses/list/helper.ts
@@ -1,0 +1,22 @@
+import { BlendedCourseType } from '../../../types/CourseTypes';
+import { StepType } from '../../../types/StepTypes';
+import companiDates from '../../../core/helpers/dates/companiDates';
+import { E_LEARNING } from '../../../core/data/constants';
+
+export const getElearningSteps = (steps: StepType[]) => steps.filter(step => step.type === E_LEARNING);
+
+export const isForthcoming = (course: BlendedCourseType) => {
+  const noSlotPlannedAndSlotToPlan = !course.slots.length && course.slotsToPlan.length;
+  const everySlotsToBeStarted = course.slots.every(slot => companiDates().isBefore(slot.startDate));
+
+  return noSlotPlannedAndSlotToPlan || everySlotsToBeStarted;
+};
+
+export const isCompleted = (course: BlendedCourseType) => {
+  const noSlotToPlan = !course.slotsToPlan.length;
+  const everySlotsHaveBeenCompleted = course.slots.every(slot => companiDates().isAfter(slot.endDate));
+
+  return noSlotToPlan && everySlotsHaveBeenCompleted;
+};
+
+export const isInProgress = (course: BlendedCourseType) => !isForthcoming(course) && !isCompleted(course);

--- a/src/screens/courses/list/styles.ts
+++ b/src/screens/courses/list/styles.ts
@@ -15,33 +15,33 @@ const styles = StyleSheet.create({
     paddingVertical: PADDING.XL,
     marginBottom: MARGIN.XL,
   },
-  onGoingCoursesCount: {
+  yellowCount: {
     ...FIRA_SANS_REGULAR.SM,
     color: YELLOW[900],
     backgroundColor: YELLOW[200],
   },
-  achievedCoursesCount: {
+  greenCount: {
     ...FIRA_SANS_REGULAR.SM,
     color: GREEN[900],
     backgroundColor: GREEN[200],
   },
-  subProgramsCount: {
+  purpleCount: {
     ...FIRA_SANS_REGULAR.SM,
     color: PURPLE[800],
     backgroundColor: PURPLE[200],
   },
-  nextEventsCount: {
+  pinkCount: {
     ...FIRA_SANS_REGULAR.SM,
     color: PINK[600],
     backgroundColor: PINK[200],
   },
-  onGoingAndDraftBackground: {
+  leftBackground: {
     resizeMode: 'contain',
     position: 'absolute',
     left: -208,
     top: -32,
   },
-  achievedBackground: {
+  rightBackground: {
     resizeMode: 'contain',
     position: 'absolute',
     right: -264,

--- a/src/screens/courses/list/types.ts
+++ b/src/screens/courses/list/types.ts
@@ -1,0 +1,9 @@
+import { BlendedCourseType } from '../../../types/CourseTypes';
+
+export type CourseDisplayType = {
+  title: string,
+  source: { uri: string },
+  imageStyle: object,
+  countStyle: object,
+  courses: BlendedCourseType[],
+}

--- a/src/types/AxiosTypes.ts
+++ b/src/types/AxiosTypes.ts
@@ -1,6 +1,6 @@
 import { ActivityWithCardsType } from './ActivityTypes';
 import { CompanyType } from './CompanyType';
-import { CourseType, ProgramType, SubProgramType } from './CourseTypes';
+import { BlendedCourseType, CourseType, ProgramType, SubProgramType } from './CourseTypes';
 import { QuestionnaireType, QuestionnaireWithCardsType } from './QuestionnaireType';
 import { UserType } from './UserType';
 
@@ -25,6 +25,7 @@ export type CompanyListResponseType = { message: string, data: { companies: Comp
 
 // COURSE
 export type CourseListResponseType = { message: string, data: { courses: CourseType[] } }
+export type BlendedCourseListResponseType = { message: string, data: { courses: BlendedCourseType[] } }
 export type CourseResponseType = { message: string, data: { course: CourseType } }
 export type PdfResponseType = { data: string }
 

--- a/src/types/CourseTypes.tsx
+++ b/src/types/CourseTypes.tsx
@@ -49,6 +49,13 @@ export type SlotType = {
   step: { _id: string, type: string },
 }
 
+export type SlotToPlanType = {
+  _id: string,
+  address?: AddressType,
+  meetingLink?: string,
+  step: { _id: string, type: string },
+}
+
 type BaseCourseType = {
   _id: string,
   progress: number,
@@ -64,6 +71,7 @@ export type ELearningCourseType = BaseCourseType & {
 export type BlendedCourseType = BaseCourseType & {
   subProgram: { isStrictlyELearning: false },
   slots: SlotType[],
+  slotsToPlan: SlotToPlanType[],
   trainer: { _id: string, identity: { lastname: string, firstname: string }, picture: { link: '' }, biography: '' },
   contact: {
     _id: string,


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone 🔴 attention Sophie ou Manon, il faut tester sur iphone
- [x] J'ai testé sur android

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] Mes changements entrainent une incompatibilité avec l'ancienne version de l'api
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : trainer

- Cas d'usage :
   - je peux voir les formations dans l'onglet formateur

- il manque : 
   - la section "les prochaines sessions que j'anime"
   - la mutualisation de certains morceaux de code entre `TrainerCourses` et `LearnerCourse` 
 => ce sera pour une prochaine PR

- Comment tester ? :
  - se connecter avec un role vendeur
  - verifer que les sections s'affichent bien
     - tester avec un, deux, et avec les trois sections affichées
  - verifier que les cellules des formations s'affichent bien
    - titre du programme
    - misc
    - image
    - description
    - durée elearning
   - verifier : 
     - qu'une formation avec des creneaux a planifier et sans creneau planifié s'affiche dans "a venir"
     - qu'une formation avec aucun creneau commencé s'affiche dans "a venir" 
     - qu'une formation avec un creneau commencé et un creneau a planifié s'affiche dans "en cours"
     - qu'une formation avec un creneau commencé et un creneau non terminé s'affiche dans 'en cours'
     - qu'une formation avec que des creneau terminés est dans "terminées"

_Si tu as lu cette description, pense a réagir avec un :eye:_
