### PR TITLE
Com 2976

### DIFF
--- a/src/components/About/index.tsx
+++ b/src/components/About/index.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Image, Text, View, ScrollView, BackHandler, ImageSourcePropType } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { connect } from 'react-redux';
 import Markdown from 'react-native-markdown-display';
 import get from 'lodash/get';
 import { useNavigation } from '@react-navigation/native';
@@ -11,8 +10,6 @@ import { GREY, TRANSPARENT_GRADIENT, WHITE } from '../../styles/colors';
 import { ICON } from '../../styles/metrics';
 import NiPrimaryButton from '../../components/form/PrimaryButton';
 import FeatherButton from '../../components/icons/FeatherButton';
-import CoursesActions from '../../store/courses/actions';
-import { ActionWithoutPayloadType } from '../../types/store/StoreType';
 import { ProgramType } from '../../types/CourseTypes';
 import FooterGradient from '../design/FooterGradient';
 
@@ -79,8 +76,4 @@ const About = ({ program, buttonCaption = 'Continuer', children, onPress }: Abou
   );
 };
 
-const mapDispatchToProps = (dispatch: ({ type }: ActionWithoutPayloadType) => void) => ({
-  setIsCourse: (isCourse: boolean) => dispatch(CoursesActions.setIsCourse(isCourse)),
-});
-
-export default connect(null, mapDispatchToProps)(About);
+export default About;

--- a/src/components/CalendarIcon/index.tsx
+++ b/src/components/CalendarIcon/index.tsx
@@ -8,19 +8,21 @@ import Shadow from '../design/Shadow';
 import styles from './styles';
 import ProgressPieChart from '../ProgressPieChart';
 import { StateType } from '../../types/store/StoreType';
+import { CourseModeType } from '../../types/store/CourseStoreType';
+import { TRAINER } from '../../core/data/constants';
 
 interface CalendarIconProps {
   slots: Date[],
   progress: number,
-  isLearner: boolean,
+  mode: CourseModeType,
 }
 
-const CalendarIcon = ({ slots, progress = 0, isLearner }: CalendarIconProps) => {
+const CalendarIcon = ({ slots, progress = 0, mode }: CalendarIconProps) => {
   const [dayOfWeek, setDayOfWeek] = useState<string>('');
   const [dayOfMonth, setDayOfMonth] = useState<string>('');
   const [month, setMonth] = useState<string>('');
   const [dates, setDates] = useState<string[]>([]);
-  const style = styles(isLearner ? PINK[500] : PURPLE[800]);
+  const style = styles(mode === TRAINER ? PURPLE[800] : PINK[500]);
   const dateFormat = 'dd/LL/yyyy';
 
   useEffect(() => {
@@ -79,6 +81,6 @@ const CalendarIcon = ({ slots, progress = 0, isLearner }: CalendarIconProps) => 
   );
 };
 
-const mapStateToProps = (state: StateType) => ({ isLearner: state.courses.isLearner });
+const mapStateToProps = (state: StateType) => ({ mode: state.courses.mode });
 
 export default connect(mapStateToProps)(CalendarIcon);

--- a/src/components/activities/ActivityCell/index.tsx
+++ b/src/components/activities/ActivityCell/index.tsx
@@ -5,18 +5,18 @@ import { useNavigation } from '@react-navigation/native';
 import { connect } from 'react-redux';
 import CardsActions from '../../../store/cards/actions';
 import { StateType } from '../../../types/store/StoreType';
+import { CourseModeType } from '../../../types/store/CourseStoreType';
 import ActivityIcon from '../ActivityIcon';
 import { ActivityType, QuestionnaireAnswersType } from '../../../types/ActivityTypes';
 import { GREEN, WHITE, ORANGE, YELLOW } from '../../../styles/colors';
 import { ICON } from '../../../styles/metrics';
-import { QUIZ } from '../../../core/data/constants';
+import { LEARNER, QUIZ } from '../../../core/data/constants';
 import styles from './styles';
 
 type ActivityCellProps = {
   activity: ActivityType,
   profileId: string,
-  isCourse: boolean,
-  isLearner: boolean,
+  mode: CourseModeType,
   setQuestionnaireAnswersList: (qalist: QuestionnaireAnswersType[]) => void,
 }
 
@@ -34,7 +34,7 @@ const colorsReducer = (state, action) => {
   }
 };
 
-const ActivityCell = ({ activity, profileId, isCourse, isLearner, setQuestionnaireAnswersList }: ActivityCellProps) => {
+const ActivityCell = ({ activity, profileId, mode, setQuestionnaireAnswersList }: ActivityCellProps) => {
   const disabled = !activity.cards.length;
   const isCompleted = !!activity.activityHistories?.length;
   const lastScore = isCompleted ? activity.activityHistories[activity.activityHistories.length - 1].score : 0;
@@ -59,7 +59,7 @@ const ActivityCell = ({ activity, profileId, isCourse, isLearner, setQuestionnai
   };
 
   const onPress = () => {
-    if (isCourse && isLearner) getQuestionnaireAnswersList();
+    if (mode === LEARNER) getQuestionnaireAnswersList();
 
     navigation.navigate('ActivityCardContainer', { activityId: activity._id, profileId });
   };
@@ -86,10 +86,7 @@ const ActivityCell = ({ activity, profileId, isCourse, isLearner, setQuestionnai
   );
 };
 
-const mapStateToProps = (state: StateType) => ({
-  isCourse: state.courses.isCourse,
-  isLearner: state.courses.isLearner,
-});
+const mapStateToProps = (state: StateType) => ({ mode: state.courses.mode });
 
 const mapDispatchToProps = dispatch => ({
   setQuestionnaireAnswersList: questionnaireAnswersList =>

--- a/src/components/steps/NextStepCell/index.tsx
+++ b/src/components/steps/NextStepCell/index.tsx
@@ -5,19 +5,21 @@ import CalendarIcon from '../../CalendarIcon';
 import StepCellTitle from '../StepCellTitle';
 import { NextSlotsStepType } from '../../../types/StepTypes';
 import { StateType } from '../../../types/store/StoreType';
+import { CourseModeType } from '../../../types/store/CourseStoreType';
+import { LEARNER } from '../../../core/data/constants';
 import styles from './styles';
 
 type NextStepCellProps = {
   nextSlotsStep: NextSlotsStepType,
-  isLearner: boolean,
+  mode: CourseModeType,
 }
 
-const NextStepCell = ({ nextSlotsStep, isLearner }: NextStepCellProps) => {
+const NextStepCell = ({ nextSlotsStep, mode }: NextStepCellProps) => {
   const { stepIndex, slots, progress, courseId, name, type, misc } = nextSlotsStep;
   const navigation = useNavigation();
 
   const goToCourse = () => {
-    navigation.navigate(isLearner ? 'LearnerCourseProfile' : 'TrainerCourseProfile', { courseId });
+    navigation.navigate(mode === LEARNER ? 'LearnerCourseProfile' : 'TrainerCourseProfile', { courseId });
   };
 
   return (
@@ -28,6 +30,6 @@ const NextStepCell = ({ nextSlotsStep, isLearner }: NextStepCellProps) => {
   );
 };
 
-const mapStateToProps = (state: StateType) => ({ isLearner: state.courses.isLearner });
+const mapStateToProps = (state: StateType) => ({ mode: state.courses.mode });
 
 export default connect(mapStateToProps)(NextStepCell);

--- a/src/components/steps/StepCellTitle/index.tsx
+++ b/src/components/steps/StepCellTitle/index.tsx
@@ -1,31 +1,32 @@
 import { View, Text } from 'react-native';
 import { connect } from 'react-redux';
 import { StepType } from '../../../types/StepTypes';
-import { stepTypeOptions, E_LEARNING } from '../../../core/data/constants';
+import { stepTypeOptions, E_LEARNING, TRAINER } from '../../../core/data/constants';
 import { formatDuration } from '../../../core/helpers/utils';
 import { StateType } from '../../../types/store/StoreType';
+import { CourseModeType } from '../../../types/store/CourseStoreType';
 import styles from './styles';
 
 type StepCellTitleProps = {
   name: StepType['name'],
   type: StepType['type'],
   index: number,
-  isLearner: boolean,
+  mode: CourseModeType,
   misc?: string,
   theoreticalHours?: number,
 }
 
-const StepCellTitle = ({ name, type, index, isLearner, misc = '', theoreticalHours = 0 }: StepCellTitleProps) => (
+const StepCellTitle = ({ name, type, index, mode, misc = '', theoreticalHours = 0 }: StepCellTitleProps) => (
   <View style={styles.textContainer}>
     <Text style={styles.stepType}>
       {`ÉTAPE ${index + 1} - ${stepTypeOptions[type]}`}
       {type === E_LEARNING && !!theoreticalHours && ` (${formatDuration(theoreticalHours)})`}
     </Text>
     <Text lineBreakMode={'tail'} numberOfLines={2} style={styles.stepName}>{name}</Text>
-    { !isLearner && <Text style={styles.misc} numberOfLines={1}>{misc}</Text>}
+    { mode === TRAINER && <Text style={styles.misc} numberOfLines={1}>{misc}</Text>}
   </View>
 );
 
-const mapStateToProps = (state: StateType) => ({ isLearner: state.courses.isLearner });
+const mapStateToProps = (state: StateType) => ({ mode: state.courses.mode });
 
 export default connect(mapStateToProps)(StepCellTitle);

--- a/src/core/data/constants.ts
+++ b/src/core/data/constants.ts
@@ -52,6 +52,10 @@ export const VENDOR_ADMIN = 'vendor_admin';
 export const TRAINING_ORGANISATION_MANAGER = 'training_organisation_manager';
 export const TRAINER = 'trainer';
 
+// COURSE MODE
+export const LEARNER = 'learner';
+export const TESTER = 'tester';
+
 // REGEX
 export const PHONE_REGEX = /^(?:(?:\+|00)33|0)\s*[1-9](?:[\s.-]*\d{2}){4}(?:[\s]*)$/;
 export const EMAIL_REGEX = /^[\w-.+]+@([\w-]+\.)+[\w-]{2,4}$/;

--- a/src/screens/courses/ActivityCardContainer/index.tsx
+++ b/src/screens/courses/ActivityCardContainer/index.tsx
@@ -11,14 +11,15 @@ import { RootCardParamList, RootStackParamList } from '../../../types/Navigation
 import StartCard from '../cardTemplates/StartCard';
 import ActivityEndCard from '../cardTemplates/ActivityEndCard';
 import { StateType } from '../../../types/store/StoreType';
+import { CourseModeType } from '../../../types/store/CourseStoreType';
 import MainActions from '../../../store/main/actions';
 import CardsActions from '../../../store/cards/actions';
 import CardScreen from '../CardScreen';
+import { LEARNER, TRAINER } from '../../../core/data/constants';
 
 interface ActivityCardContainerProps extends StackScreenProps<RootStackParamList, 'ActivityCardContainer'> {
   cardIndex: number | null,
-  isCourse: boolean,
-  isLearner: boolean,
+  mode: CourseModeType,
   exitConfirmationModal: boolean,
   cards: CardType[],
   setCards: (activity: CardType[] | null) => void,
@@ -32,8 +33,7 @@ const ActivityCardContainer = ({
   navigation,
   cards,
   cardIndex,
-  isCourse,
-  isLearner,
+  mode,
   exitConfirmationModal,
   setCards,
   setExitConfirmationModal,
@@ -82,10 +82,10 @@ const ActivityCardContainer = ({
     if (exitConfirmationModal) setExitConfirmationModal(false);
 
     const { profileId } = route.params;
-    if (!isLearner) navigation.navigate('TrainerCourseProfile', { courseId: profileId });
-    else if (isCourse) {
+    if (mode === LEARNER) {
       navigation.navigate('LearnerCourseProfile', { courseId: profileId, endedActivity: activity?._id });
-    } else navigation.navigate('SubProgramProfile', { subProgramId: profileId });
+    } else if (mode === TRAINER) navigation.navigate('TrainerCourseProfile', { courseId: profileId });
+    else navigation.navigate('SubProgramProfile', { subProgramId: profileId });
 
     setIsActive(false);
     resetCardReducer();
@@ -132,8 +132,7 @@ const mapStateToProps = (state: StateType) => ({
   cards: state.cards.cards,
   cardIndex: state.cards.cardIndex,
   exitConfirmationModal: state.cards.exitConfirmationModal,
-  isCourse: state.courses.isCourse,
-  isLearner: state.courses.isLearner,
+  mode: state.courses.mode,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/screens/courses/SubProgramProfile/index.tsx
+++ b/src/screens/courses/SubProgramProfile/index.tsx
@@ -26,7 +26,6 @@ import { E_LEARNING } from '../../../core/data/constants';
 import commonStyles from '../../../styles/common';
 import styles from './styles';
 import MainActions from '../../../store/main/actions';
-import CoursesActions from '../../../store/courses/actions';
 import { RootStackParamList, RootBottomTabParamList } from '../../../types/NavigationType';
 import { SubProgramType } from '../../../types/CourseTypes';
 

--- a/src/screens/courses/SubProgramProfile/index.tsx
+++ b/src/screens/courses/SubProgramProfile/index.tsx
@@ -37,10 +37,9 @@ StackScreenProps<RootStackParamList, 'SubProgramProfile'>,
 StackScreenProps<RootBottomTabParamList>
 > {
   setStatusBarVisible: (boolean) => void,
-  resetCourseReducer: () => void,
 }
 
-const SubProgramProfile = ({ route, navigation, setStatusBarVisible, resetCourseReducer }: SubProgramProfileProps) => {
+const SubProgramProfile = ({ route, navigation, setStatusBarVisible }: SubProgramProfileProps) => {
   const [subProgram, setSubProgram] = useState<SubProgramType | null>(null);
   const [source, setSource] =
     useState<ImageSourcePropType>(require('../../../../assets/images/authentication_background_image.jpg'));
@@ -75,9 +74,8 @@ const SubProgramProfile = ({ route, navigation, setStatusBarVisible, resetCourse
   }, [getSubProgram, isFocused, setStatusBarVisible]);
 
   const goBack = useCallback(() => {
-    resetCourseReducer();
     navigation.navigate('LearnerCourses');
-  }, [navigation, resetCourseReducer]);
+  }, [navigation]);
 
   const hardwareBackPress = useCallback(() => {
     goBack();
@@ -121,7 +119,6 @@ const SubProgramProfile = ({ route, navigation, setStatusBarVisible, resetCourse
 
 const mapDispatchToProps = dispatch => ({
   setStatusBarVisible: statusBarVisible => dispatch(MainActions.setStatusBarVisible(statusBarVisible)),
-  resetCourseReducer: () => dispatch(CoursesActions.resetCourseReducer()),
 });
 
 export default connect(null, mapDispatchToProps)(SubProgramProfile);

--- a/src/screens/courses/cardTemplates/ActivityEndCard/index.tsx
+++ b/src/screens/courses/cardTemplates/ActivityEndCard/index.tsx
@@ -35,18 +35,18 @@ const ActivityEndCard = ({
   const isFocused = useIsFocused();
 
   useEffect(() => {
-    async function fetchData() {
+    async function saveHistory() {
       const userId = await asyncStorage.getUserId();
       const payload = questionnaireAnswersList?.length
         ? { user: userId, activity: activity._id, score, questionnaireAnswersList }
         : { user: userId, activity: activity._id, score };
 
       await ActivityHistories.createActivityHistories(payload);
-      setCardIndex(null);
     }
 
     if (isFocused) {
-      if (mode === LEARNER) fetchData();
+      if (mode === LEARNER) saveHistory();
+      setCardIndex(null);
       achievementJingle();
     }
   }, [isFocused, activity, questionnaireAnswersList, setCardIndex, score, mode]);

--- a/src/screens/courses/cardTemplates/ActivityEndCard/index.tsx
+++ b/src/screens/courses/cardTemplates/ActivityEndCard/index.tsx
@@ -6,15 +6,17 @@ import { useIsFocused } from '@react-navigation/native';
 import asyncStorage from '../../../../core/helpers/asyncStorage';
 import NiPrimaryButton from '../../../../components/form/PrimaryButton';
 import { StateType } from '../../../../types/store/StoreType';
+import { CourseModeType } from '../../../../types/store/CourseStoreType';
 import ActivityHistories from '../../../../api/activityHistories';
 import { ActivityType, QuestionnaireAnswersType } from '../../../../types/ActivityTypes';
 import CardsActions from '../../../../store/cards/actions';
 import styles from '../../../../styles/endCard';
 import commonStyles from '../../../../styles/common';
 import { achievementJingle } from '../../../../core/helpers/utils';
+import { LEARNER } from '../../../../core/data/constants';
 
 interface ActivityEndCardProps {
-  isCourse: boolean,
+  mode: CourseModeType,
   activity: ActivityType,
   questionnaireAnswersList: QuestionnaireAnswersType[],
   score: number,
@@ -23,7 +25,7 @@ interface ActivityEndCardProps {
 }
 
 const ActivityEndCard = ({
-  isCourse,
+  mode,
   activity,
   questionnaireAnswersList,
   score,
@@ -44,10 +46,10 @@ const ActivityEndCard = ({
     }
 
     if (isFocused) {
-      if (isCourse) fetchData();
+      if (mode === LEARNER) fetchData();
       achievementJingle();
     }
-  }, [isFocused, activity, questionnaireAnswersList, setCardIndex, score, isCourse]);
+  }, [isFocused, activity, questionnaireAnswersList, setCardIndex, score, mode]);
 
   return (
     <SafeAreaView style={commonStyles.container} edges={['top']}>
@@ -65,7 +67,7 @@ const ActivityEndCard = ({
 const mapStateToProps = (state: StateType) => ({
   questionnaireAnswersList: state.cards.questionnaireAnswersList,
   score: state.cards.score,
-  isCourse: state.courses.isCourse,
+  mode: state.courses.mode,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/screens/courses/list/LearnerCourses/index.tsx
+++ b/src/screens/courses/list/LearnerCourses/index.tsx
@@ -19,8 +19,9 @@ import { RootBottomTabParamList, RootStackParamList } from '../../../../types/Na
 import { SubProgramType } from '../../../../types/CourseTypes';
 import { NextSlotsStepType } from '../../../../types/StepTypes';
 import { ActionWithoutPayloadType } from '../../../../types/store/StoreType';
+import { CourseModeType } from '../../../../types/store/CourseStoreType';
 import { getCourseProgress, getTheoreticalHours } from '../../../../core/helpers/utils';
-import { E_LEARNING } from '../../../../core/data/constants';
+import { E_LEARNING, LEARNER, TESTER } from '../../../../core/data/constants';
 import styles from '../styles';
 import { formatNextSteps } from '../helper';
 import LearnerEmptyState from '../LearnerEmptyState';
@@ -29,8 +30,7 @@ interface LearnerCoursesProps extends CompositeScreenProps<
 StackScreenProps<RootBottomTabParamList>,
 StackScreenProps<RootStackParamList>
 > {
-  setIsCourse: (value: boolean) => void,
-  setIsLearner: (value: boolean) => void,
+  setMode: (value: CourseModeType) => void,
   loggedUserId: string | null,
 }
 
@@ -53,7 +53,7 @@ const courseReducer = (state, action) => {
 
 const renderNextStepsItem = (step: NextSlotsStepType) => <NextStepCell nextSlotsStep={step} />;
 
-const LearnerCourses = ({ setIsCourse, setIsLearner, navigation, loggedUserId }: LearnerCoursesProps) => {
+const LearnerCourses = ({ setMode, navigation, loggedUserId }: LearnerCoursesProps) => {
   const [courses, dispatch] = useReducer(courseReducer, { onGoing: [], achieved: [] });
   const [elearningDraftSubPrograms, setElearningDraftSubPrograms] = useState<SubProgramType[]>(new Array(0));
 
@@ -83,20 +83,17 @@ const LearnerCourses = ({ setIsCourse, setIsLearner, navigation, loggedUserId }:
     async function fetchData() {
       await Promise.all([getCourses(), getElearningDraftSubPrograms()]);
     }
-    if (loggedUserId && isFocused) {
-      fetchData();
-      setIsLearner(true);
-    }
-  }, [loggedUserId, isFocused, getCourses, getElearningDraftSubPrograms, setIsLearner]);
-
-  const goToCourse = (id: string, isCourse: boolean) => {
-    if (isCourse) navigation.navigate('LearnerCourseProfile', { courseId: id });
-    else navigation.navigate('SubProgramProfile', { subProgramId: id });
-  };
+    if (loggedUserId && isFocused) fetchData();
+  }, [loggedUserId, isFocused, getCourses, getElearningDraftSubPrograms, setMode]);
 
   const onPressProgramCell = (id: string, isCourse: boolean) => {
-    setIsCourse(isCourse);
-    goToCourse(id, isCourse);
+    if (isCourse) {
+      setMode(LEARNER);
+      navigation.navigate('LearnerCourseProfile', { courseId: id });
+    } else {
+      setMode(TESTER);
+      navigation.navigate('SubProgramProfile', { subProgramId: id });
+    }
   };
 
   const getElearningSteps = steps => steps.filter(step => step.type === E_LEARNING);
@@ -149,8 +146,7 @@ const LearnerCourses = ({ setIsCourse, setIsLearner, navigation, loggedUserId }:
 const mapStateToProps = state => ({ loggedUserId: getLoggedUserId(state) });
 
 const mapDispatchToProps = (dispatch: ({ type }: ActionWithoutPayloadType) => void) => ({
-  setIsCourse: (isCourse: boolean) => dispatch(CoursesActions.setIsCourse(isCourse)),
-  setIsLearner: (isLearner: boolean) => dispatch(CoursesActions.setIsLearner(isLearner)),
+  setMode: (value: CourseModeType) => dispatch(CoursesActions.setMode(value)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(LearnerCourses);

--- a/src/screens/courses/list/LearnerCourses/index.tsx
+++ b/src/screens/courses/list/LearnerCourses/index.tsx
@@ -83,14 +83,16 @@ const LearnerCourses = ({ setMode, navigation, loggedUserId }: LearnerCoursesPro
     async function fetchData() {
       await Promise.all([getCourses(), getElearningDraftSubPrograms()]);
     }
-    if (loggedUserId && isFocused) fetchData();
+    if (loggedUserId && isFocused) {
+      console.log('set mode to LEARNER from LearnerCourse');
+      setMode(LEARNER);
+      fetchData();
+    }
   }, [loggedUserId, isFocused, getCourses, getElearningDraftSubPrograms, setMode]);
 
   const onPressProgramCell = (id: string, isCourse: boolean) => {
-    if (isCourse) {
-      setMode(LEARNER);
-      navigation.navigate('LearnerCourseProfile', { courseId: id });
-    } else {
+    if (isCourse) navigation.navigate('LearnerCourseProfile', { courseId: id });
+    else {
       setMode(TESTER);
       navigation.navigate('SubProgramProfile', { subProgramId: id });
     }

--- a/src/screens/courses/list/LearnerCourses/index.tsx
+++ b/src/screens/courses/list/LearnerCourses/index.tsx
@@ -84,7 +84,6 @@ const LearnerCourses = ({ setMode, navigation, loggedUserId }: LearnerCoursesPro
       await Promise.all([getCourses(), getElearningDraftSubPrograms()]);
     }
     if (loggedUserId && isFocused) {
-      console.log('set mode to LEARNER from LearnerCourse');
       setMode(LEARNER);
       fetchData();
     }

--- a/src/screens/courses/list/TrainerCourses/index.tsx
+++ b/src/screens/courses/list/TrainerCourses/index.tsx
@@ -17,12 +17,13 @@ import { NextSlotsStepType } from '../../../../types/StepTypes';
 import { RootBottomTabParamList, RootStackParamList } from '../../../../types/NavigationType';
 import { getLoggedUserId } from '../../../../store/main/selectors';
 import commonStyles from '../../../../styles/common';
-import { BLENDED, OPERATIONS } from '../../../../core/data/constants';
+import { BLENDED, OPERATIONS, TRAINER } from '../../../../core/data/constants';
 import styles from '../styles';
 import { isInProgress, isForthcoming, isCompleted, getElearningSteps, formatNextSteps } from '../helper';
 import { CourseDisplayType } from '../types';
 import TrainerEmptyState from '../TrainerEmptyState';
 import { ActionWithoutPayloadType } from '../../../../types/store/StoreType';
+import { CourseModeType } from '../../../../types/store/CourseStoreType';
 import CoursesActions from '../../../../store/courses/actions';
 
 const formatCoursesDiplaysContent = (courses: BlendedCourseType[]) => {
@@ -63,11 +64,11 @@ interface TrainerCoursesProps extends CompositeScreenProps<
 StackScreenProps<RootBottomTabParamList>,
 StackScreenProps<RootStackParamList>
 > {
-  setIsLearner: (value: boolean) => void,
+  setMode: (value: CourseModeType) => void,
   loggedUserId: string | null,
 }
 
-const TrainerCourses = ({ setIsLearner, navigation, loggedUserId }: TrainerCoursesProps) => {
+const TrainerCourses = ({ setMode, navigation, loggedUserId }: TrainerCoursesProps) => {
   const [coursesDisplays, setCoursesDisplays] = useState<CourseDisplayType[]>([]);
   const [nextSteps, setNextSteps] = useState<NextSlotsStepType[]>([]);
   const isFocused = useIsFocused();
@@ -103,9 +104,9 @@ const TrainerCourses = ({ setIsLearner, navigation, loggedUserId }: TrainerCours
   useEffect(() => {
     if (isFocused) {
       getCourses();
-      setIsLearner(false);
+      setMode(TRAINER);
     }
-  }, [isFocused, getCourses, loggedUserId, setIsLearner]);
+  }, [isFocused, getCourses, loggedUserId, setMode]);
 
   return (
     <SafeAreaView style={commonStyles.container} edges={['top']}>
@@ -136,7 +137,7 @@ const TrainerCourses = ({ setIsLearner, navigation, loggedUserId }: TrainerCours
 const mapStateToProps = state => ({ loggedUserId: getLoggedUserId(state) });
 
 const mapDispatchToProps = (dispatch: ({ type }: ActionWithoutPayloadType) => void) => ({
-  setIsLearner: (isLearner: boolean) => dispatch(CoursesActions.setIsLearner(isLearner)),
+  setMode: (value: CourseModeType) => dispatch(CoursesActions.setMode(value)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(TrainerCourses);

--- a/src/screens/courses/list/TrainerCourses/index.tsx
+++ b/src/screens/courses/list/TrainerCourses/index.tsx
@@ -97,7 +97,7 @@ const TrainerCourses = ({ setMode, navigation, loggedUserId }: TrainerCoursesPro
     navigation.navigate('TrainerCourseProfile', { courseId: id });
   };
 
-  const renderCourseItem = (course: BlendedCourseType) => <ProgramCell program={get(course, 'subProgram.program') || {}}
+  const renderItem = (course: BlendedCourseType) => <ProgramCell program={get(course, 'subProgram.program') || {}}
     misc={course.misc} theoreticalHours={getTheoreticalHours(getElearningSteps(get(course, 'subProgram.steps')))}
     onPress={() => goToCourse(course._id)} />;
 
@@ -123,7 +123,7 @@ const TrainerCourses = ({ setMode, navigation, loggedUserId }: TrainerCoursesPro
             <ImageBackground imageStyle={content.imageStyle} style={styles.sectionContainer}
               key={content.title} source={content.source}>
               <CoursesSection items={content.courses} title={content.title}
-                countStyle={content.countStyle} renderItem={renderCourseItem} />
+                countStyle={content.countStyle} renderItem={renderItem} />
             </ImageBackground>
           ))
           : <TrainerEmptyState />

--- a/src/screens/courses/profile/LearnerCourseProfile/index.tsx
+++ b/src/screens/courses/profile/LearnerCourseProfile/index.tsx
@@ -51,7 +51,6 @@ StackScreenProps<RootBottomTabParamList>
 > {
   userId: string,
   setStatusBarVisible: (boolean) => void,
-  resetCourseReducer: () => void,
 }
 
 const LearnerCourseProfile = ({
@@ -59,7 +58,6 @@ const LearnerCourseProfile = ({
   navigation,
   userId,
   setStatusBarVisible,
-  resetCourseReducer,
 }: LearnerCourseProfileProps) => {
   const [course, setCourse] = useState<CourseType | null>(null);
   const [questionnaires, setQuestionnaires] = useState<QuestionnaireType[]>([]);
@@ -95,9 +93,8 @@ const LearnerCourseProfile = ({
   }, [isFocused, setStatusBarVisible, route.params.courseId]);
 
   const goBack = useCallback(() => {
-    resetCourseReducer();
     navigation.navigate('LearnerCourses');
-  }, [navigation, resetCourseReducer]);
+  }, [navigation]);
 
   const hardwareBackPress = useCallback(() => {
     goBack();
@@ -216,7 +213,6 @@ const mapStateToProps = state => ({ userId: getLoggedUserId(state) });
 
 const mapDispatchToProps = dispatch => ({
   setStatusBarVisible: statusBarVisible => dispatch(MainActions.setStatusBarVisible(statusBarVisible)),
-  resetCourseReducer: () => dispatch(CoursesActions.resetCourseReducer()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(LearnerCourseProfile);

--- a/src/screens/courses/profile/LearnerCourseProfile/index.tsx
+++ b/src/screens/courses/profile/LearnerCourseProfile/index.tsx
@@ -31,7 +31,6 @@ import commonStyles from '../../../../styles/common';
 import { CourseType, BlendedCourseType, ELearningProgramType } from '../../../../types/CourseTypes';
 import styles from '../styles';
 import MainActions from '../../../../store/main/actions';
-import CoursesActions from '../../../../store/courses/actions';
 import ProgressBar from '../../../../components/cards/ProgressBar';
 import CourseProfileStickyHeader from '../../../../components/CourseProfileStickyHeader';
 import NiSecondaryButton from '../../../../components/form/SecondaryButton';

--- a/src/screens/courses/profile/TrainerCourseProfile/index.tsx
+++ b/src/screens/courses/profile/TrainerCourseProfile/index.tsx
@@ -13,7 +13,6 @@ import commonStyles from '../../../../styles/common';
 import { CourseType, BlendedCourseType } from '../../../../types/CourseTypes';
 import styles from '../styles';
 import MainActions from '../../../../store/main/actions';
-import CoursesActions from '../../../../store/courses/actions';
 import NiSecondaryButton from '../../../../components/form/SecondaryButton';
 import { getLoggedUserId } from '../../../../store/main/selectors';
 import CourseProfileHeader from '../../../../components/CourseProfileHeader';

--- a/src/screens/courses/profile/TrainerCourseProfile/index.tsx
+++ b/src/screens/courses/profile/TrainerCourseProfile/index.tsx
@@ -28,14 +28,12 @@ StackScreenProps<RootBottomTabParamList>
 > {
   userId: string,
   setStatusBarVisible: (boolean) => void,
-  resetCourseReducer: () => void,
 }
 
 const TrainerCourseProfile = ({
   route,
   navigation,
   setStatusBarVisible,
-  resetCourseReducer,
 }: TrainerCourseProfileProps) => {
   const [course, setCourse] = useState<CourseType | null>(null);
   const [source, setSource] =
@@ -65,9 +63,8 @@ const TrainerCourseProfile = ({
   }, [isFocused, route.params.courseId, setStatusBarVisible]);
 
   const goBack = useCallback(() => {
-    resetCourseReducer();
     navigation.navigate('TrainerCourses');
-  }, [navigation, resetCourseReducer]);
+  }, [navigation]);
 
   const hardwareBackPress = useCallback(() => {
     goBack();
@@ -106,7 +103,6 @@ const mapStateToProps = state => ({ userId: getLoggedUserId(state) });
 
 const mapDispatchToProps = dispatch => ({
   setStatusBarVisible: statusBarVisible => dispatch(MainActions.setStatusBarVisible(statusBarVisible)),
-  resetCourseReducer: () => dispatch(CoursesActions.resetCourseReducer()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(TrainerCourseProfile);

--- a/src/screens/explore/BlendedAbout/index.tsx
+++ b/src/screens/explore/BlendedAbout/index.tsx
@@ -15,9 +15,11 @@ import InternalRulesModal from '../../../components/InternalRulesModal';
 import { ICON } from '../../../styles/metrics';
 import { GREY } from '../../../styles/colors';
 import { StateType } from '../../../types/store/StoreType';
+import { CourseModeType } from '../../../types/store/CourseStoreType';
+import { LEARNER } from '../../../core/data/constants';
 
 interface BlendedAboutProps extends StackScreenProps<RootStackParamList, 'BlendedAbout'> {
-  isLearner: boolean,
+  mode: CourseModeType,
 }
 
 const formatDate = (date) => {
@@ -28,7 +30,7 @@ const formatDate = (date) => {
   return `${dayOfWeek} ${dayOfMonth} ${month} ${year}`;
 };
 
-const BlendedAbout = ({ isLearner, route, navigation }: BlendedAboutProps) => {
+const BlendedAbout = ({ mode, route, navigation }: BlendedAboutProps) => {
   const { course } = route.params;
   const program = course.subProgram?.program || null;
   const [trainerPictureSource, setTrainerPictureSource] = useState(
@@ -52,7 +54,7 @@ const BlendedAbout = ({ isLearner, route, navigation }: BlendedAboutProps) => {
 
   const goToCourse = () => {
     if (course._id) {
-      navigation.navigate(isLearner ? 'LearnerCourseProfile' : 'TrainerCourseProfile', { courseId: course._id });
+      navigation.navigate(mode === LEARNER ? 'LearnerCourseProfile' : 'TrainerCourseProfile', { courseId: course._id });
     }
   };
 
@@ -100,6 +102,6 @@ const BlendedAbout = ({ isLearner, route, navigation }: BlendedAboutProps) => {
   );
 };
 
-const mapStateToProps = (state: StateType) => ({ isLearner: state.courses.isLearner });
+const mapStateToProps = (state: StateType) => ({ mode: state.courses.mode });
 
 export default connect(mapStateToProps)(BlendedAbout);

--- a/src/screens/explore/Catalog/index.tsx
+++ b/src/screens/explore/Catalog/index.tsx
@@ -7,6 +7,7 @@ import { useIsFocused, CompositeScreenProps } from '@react-navigation/native';
 import { StackScreenProps } from '@react-navigation/stack';
 import get from 'lodash/get';
 import { RootBottomTabParamList, RootStackParamList } from '../../../types/NavigationType';
+import CoursesActions from '../../../store/courses/actions';
 import Programs from '../../../api/programs';
 import { ELearningProgramType } from '../../../types/CourseTypes';
 import commonStyles from '../../../styles/common';
@@ -23,6 +24,7 @@ StackScreenProps<RootBottomTabParamList>,
 StackScreenProps<RootStackParamList>
 > {
   loggedUserId: string | null,
+  resetCourseReducer: () => void,
 }
 
 const CategoriesStyleList = [
@@ -48,7 +50,7 @@ const CategoriesStyleList = [
   },
 ];
 
-const Catalog = ({ loggedUserId, navigation }: CatalogProps) => {
+const Catalog = ({ loggedUserId, navigation, resetCourseReducer }: CatalogProps) => {
   const [programsByCategories, setProgramsByCategories] = useState<object>({});
   const isFocused = useIsFocused();
   const style = styles();
@@ -68,7 +70,10 @@ const Catalog = ({ loggedUserId, navigation }: CatalogProps) => {
 
   useEffect(() => {
     async function fetchData() { await getPrograms(); }
-    if (loggedUserId && isFocused) fetchData();
+    if (loggedUserId && isFocused) {
+      resetCourseReducer();
+      fetchData();
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loggedUserId, isFocused]);
 
@@ -95,4 +100,8 @@ const Catalog = ({ loggedUserId, navigation }: CatalogProps) => {
 
 const mapStateToProps = state => ({ loggedUserId: getLoggedUserId(state) });
 
-export default connect(mapStateToProps)(Catalog);
+const mapDispatchToProps = dispatch => ({
+  resetCourseReducer: () => dispatch(CoursesActions.resetCourseReducer()),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Catalog);

--- a/src/screens/explore/Catalog/index.tsx
+++ b/src/screens/explore/Catalog/index.tsx
@@ -70,12 +70,11 @@ const Catalog = ({ loggedUserId, navigation, resetCourseReducer }: CatalogProps)
 
   useEffect(() => {
     async function fetchData() { await getPrograms(); }
-    if (loggedUserId && isFocused) {
+    if (isFocused) {
       resetCourseReducer();
       fetchData();
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loggedUserId, isFocused]);
+  }, [loggedUserId, isFocused, resetCourseReducer]);
 
   const goToProgram = (program: ELearningProgramType) => navigation.navigate('ElearningAbout', { program });
 

--- a/src/screens/explore/ELearningAbout/index.tsx
+++ b/src/screens/explore/ELearningAbout/index.tsx
@@ -8,15 +8,17 @@ import Courses from '../../../api/courses';
 import { getLoggedUserId } from '../../../store/main/selectors';
 import CoursesActions from '../../../store/courses/actions';
 import { ActionWithoutPayloadType } from '../../../types/store/StoreType';
+import { CourseModeType } from '../../../types/store/CourseStoreType';
 import { ELearningCourseType } from '../../../types/CourseTypes';
 import About from '../../../components/About';
+import { LEARNER } from '../../../core/data/constants';
 
 interface ElearningAboutProps extends StackScreenProps<RootStackParamList, 'ElearningAbout'> {
   loggedUserId: string,
-  setIsCourse: (value: boolean) => void,
+  setMode: (value: CourseModeType) => void,
 }
 
-const ElearningAbout = ({ route, navigation, loggedUserId, setIsCourse }: ElearningAboutProps) => {
+const ElearningAbout = ({ route, navigation, loggedUserId, setMode }: ElearningAboutProps) => {
   const { program } = route.params;
   const [hasAlreadySubscribed, setHasAlreadySubscribed] = useState(false);
   const [courseId, setCourseId] = useState<string>('');
@@ -42,7 +44,7 @@ const ElearningAbout = ({ route, navigation, loggedUserId, setIsCourse }: Elearn
 
   const subscribeAndGoToCourseProfile = async () => {
     try {
-      setIsCourse(true);
+      setMode(LEARNER);
       if (!hasAlreadySubscribed) {
         await Courses.registerToELearningCourse(courseId);
         startActivity();
@@ -62,7 +64,7 @@ const ElearningAbout = ({ route, navigation, loggedUserId, setIsCourse }: Elearn
 const mapStateToProps = state => ({ loggedUserId: getLoggedUserId(state) });
 
 const mapDispatchToProps = (dispatch: ({ type }: ActionWithoutPayloadType) => void) => ({
-  setIsCourse: (isCourse: boolean) => dispatch(CoursesActions.setIsCourse(isCourse)),
+  setMode: (value: CourseModeType) => dispatch(CoursesActions.setMode(value)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(ElearningAbout);

--- a/src/screens/profile/Profile/index.tsx
+++ b/src/screens/profile/Profile/index.tsx
@@ -4,10 +4,11 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { connect } from 'react-redux';
 import get from 'lodash/get';
 import { StackScreenProps } from '@react-navigation/stack';
-import { CompositeScreenProps } from '@react-navigation/native';
 import { CameraCapturedPicture } from 'expo-camera';
+import { CompositeScreenProps, useIsFocused } from '@react-navigation/native';
 import { RootBottomTabParamList, RootStackParamList } from '../../../types/NavigationType';
 import { formatPhone, getCourseProgress } from '../../../core/helpers/utils';
+import CoursesActions from '../../../store/courses/actions';
 import NiSecondaryButton from '../../../components/form/SecondaryButton';
 import NiPrimaryButton from '../../../components/form/PrimaryButton';
 import commonStyles from '../../../styles/common';
@@ -35,10 +36,12 @@ StackScreenProps<RootStackParamList>
 > {
   loggedUser: UserType,
   setLoggedUser: (user: UserType) => void,
+  resetCourseReducer: () => void,
 }
 
-const Profile = ({ loggedUser, setLoggedUser, navigation }: ProfileProps) => {
+const Profile = ({ loggedUser, setLoggedUser, resetCourseReducer, navigation }: ProfileProps) => {
   const { signOut } = useContext(AuthContext);
+  const isFocused = useIsFocused();
   const [onGoingCoursesCount, setOnGoingCoursesCount] = useState<number>();
   const [achievedCoursesCount, setAchievedCoursesCount] = useState<number>();
   const [source, setSource] = useState(require('../../../../assets/images/default_avatar.png'));
@@ -70,10 +73,13 @@ const Profile = ({ loggedUser, setLoggedUser, navigation }: ProfileProps) => {
 
   useEffect(() => {
     async function fetchData() { await getUserCourses(); }
-    fetchData();
-    setUserFirstName(get(loggedUser, 'identity.firstname'));
+    if (loggedUser && isFocused) {
+      fetchData();
+      setUserFirstName(get(loggedUser, 'identity.firstname'));
+      resetCourseReducer();
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [isFocused]);
 
   const renderCompanyLinkRequest = () => {
     if (loggedUser.companyLinkRequest) {
@@ -183,6 +189,7 @@ const mapStateToProps = state => ({ loggedUser: state.main.loggedUser });
 
 const mapDispatchToProps = (dispatch: ({ type }: ActionType | ActionWithoutPayloadType) => void) => ({
   setLoggedUser: (user: UserType) => dispatch(MainActions.setLoggedUser(user)),
+  resetCourseReducer: () => dispatch(CoursesActions.resetCourseReducer()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Profile);

--- a/src/screens/profile/Profile/index.tsx
+++ b/src/screens/profile/Profile/index.tsx
@@ -73,13 +73,12 @@ const Profile = ({ loggedUser, setLoggedUser, resetCourseReducer, navigation }: 
 
   useEffect(() => {
     async function fetchData() { await getUserCourses(); }
-    if (loggedUser && isFocused) {
+    if (isFocused) {
       fetchData();
       setUserFirstName(get(loggedUser, 'identity.firstname'));
       resetCourseReducer();
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isFocused]);
+  }, [isFocused, loggedUser, resetCourseReducer]);
 
   const renderCompanyLinkRequest = () => {
     if (loggedUser.companyLinkRequest) {

--- a/src/store/courses/actions.ts
+++ b/src/store/courses/actions.ts
@@ -1,18 +1,15 @@
 import {
-  SetIsCourseType,
-  SET_IS_COURSE,
-  SET_IS_LEARNER,
+  CourseModeType,
+  SET_MODE,
   RESET_COURSE_REDUCER,
-  SetIsLearnerType,
+  SetModeType,
 } from '../../types/store/CourseStoreType';
 import { ActionWithoutPayloadType } from '../../types/store/StoreType';
 
-const setIsCourse = (isCourse: boolean): SetIsCourseType => ({ type: SET_IS_COURSE, value: isCourse });
-const setIsLearner = (isLearner: boolean): SetIsLearnerType => ({ type: SET_IS_LEARNER, value: isLearner });
+const setMode = (mode: CourseModeType): SetModeType => ({ type: SET_MODE, value: mode });
 const resetCourseReducer = (): ActionWithoutPayloadType => ({ type: RESET_COURSE_REDUCER });
 
 export default {
-  setIsCourse,
-  setIsLearner,
+  setMode,
   resetCourseReducer,
 };

--- a/src/store/courses/reducers.ts
+++ b/src/store/courses/reducers.ts
@@ -1,23 +1,21 @@
 import {
   CourseStateType,
-  SET_IS_COURSE,
-  SET_IS_LEARNER,
+  SET_MODE,
   CourseActionWithoutPayloadType,
   RESET_COURSE_REDUCER,
 } from '../../types/store/CourseStoreType';
 import { defaultAction, DefaultActionType } from '../../types/store/StoreType';
+import { LEARNER } from '../../core/data/constants';
 
-const initialState: CourseStateType = { isCourse: true, isLearner: true };
+const initialState: CourseStateType = { mode: LEARNER };
 
 export const courses = (
   state: CourseStateType = initialState,
   action: CourseActionWithoutPayloadType | DefaultActionType = defaultAction
 ): CourseStateType => {
   switch (action.type) {
-    case SET_IS_COURSE:
-      return { ...state, isCourse: action.value };
-    case SET_IS_LEARNER:
-      return { ...state, isLearner: action.value };
+    case SET_MODE:
+      return { ...state, mode: action.value };
     case RESET_COURSE_REDUCER:
       return initialState;
     default:

--- a/src/types/store/CourseStoreType.ts
+++ b/src/types/store/CourseStoreType.ts
@@ -1,25 +1,21 @@
+import { LEARNER, TESTER, TRAINER } from '../../core/data/constants';
 // Actions types
-export const SET_IS_COURSE = 'SET_IS_COURSE';
-export const SET_IS_LEARNER = 'SET_IS_LEARNER';
+export const SET_MODE = 'SET_MODE';
 export const RESET_COURSE_REDUCER = 'RESET_COURSE_REDUCER';
 
-export type SetIsCourseType = {
-  type: typeof SET_IS_COURSE,
-  value: boolean,
-}
-
-export type SetIsLearnerType = {
-  type: typeof SET_IS_LEARNER,
-  value: boolean,
+export type SetModeType = {
+  type: typeof SET_MODE,
+  value: CourseModeType,
 }
 
 export type ResetCourseReducer = {
   type: typeof RESET_COURSE_REDUCER,
 }
 
-export type CourseActionWithoutPayloadType = ResetCourseReducer | SetIsCourseType | SetIsLearnerType;
+export type CourseActionWithoutPayloadType = ResetCourseReducer | SetModeType;
+
+export type CourseModeType = typeof LEARNER | typeof TESTER | typeof TRAINER;
 
 export type CourseStateType = {
-  isCourse: boolean,
-  isLearner: boolean,
+  mode: CourseModeType,
 }


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone
- [ ] J'ai testé sur android

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] Mes changements entrainent une incompatibilité avec l'ancienne version de l'api
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : toute l'app

- Cas d'usage :
   - refacto des clés `isCOurse` et `isLearner` sur redux, sur le CourseStore
   - je modifie la valeur du store:
       - dans Catalog
         - a chaque isFocused : reinitialisation du store => et donc LEANER
         - qd on clique sur une formation : LEARNER
       - dans LearnerCOurses
          - a chaque isFocused : LEANER
          - qd je clique sur un programme a tester : TESTER
       - dans TrainerCourses, q chaque isFocused : TRAINER
       - dans profil : a chaque isFocused : reinitialisation du store => et donc LEANER
    - j'utilise cette valeur
      - pour que les historiques d'activité ne soient envoyé au back que pour LEARNER
      - pour afficher la bonne couleur sur les icones calendrier
      - pour naviguer vers le bon profile depuis les icone calendrier
      - pour afficher ou pas les infos complementaires depuis une icone calendrier

- Comment tester ? :
   - depuis le Catalog:
       - inscription a une formation
          - une fois la premiere activité terminé : l'historique doit etre enregistré 
          - retour en arriere : je suis sur l'onglet mes formations apprenant
       - cliquer sur l'onglet apprenant 
         - tout s'affiche bien
       - cliquer sur l'onglet formateur
         - un petit glitch sur les icones calendrier : rose => violette
         - sinon l'onglet s'affiche bien
       - cliquer sur profile
          - ras
   - depuis l'onglet apprenant
      - cliquer sur une formation Elearning
         - faire une activité : l'historique est enregistré
         - cliquer sur "a propos", revenir : on est au meme endrois
         - revenir en arriere : en est sur l'onglet apprenant
      - cliquer sur une formation blended
         - pareil que pour elearning
      - cliquer sur un programme a tester:
         - faire une activité : l'historique ne s'enregistre pas
         - revenir en arriere: on est sur l;onglet apprenant
      - cliquer sur l'onglet formateur
         - un petit glitch sur les icones calendrier : rose => violette
         - sinon ras
   - depuis l'onglet formateur
      - les icones sont violette et je vois les infos complementaires
      - cliquer sur une formation
         - faire une activité : l'historique n'est pas enregistré
         - cliquer sur "a propos", revenir : on est au meme endrois
         - revenir en arriere : en est sur l'onglet formateur
      - cliquer sur l'onglet apprenant
         - un petit glitch sur les icones calendrier : violette => rose
         - sinon ras
    - depuis le Profile:
       - cliquer sur l'onglet apprenant 
         - tout s'affiche bien
       - cliquer sur l'onglet formateur
         - un petit glitch sur les icones calendrier : rose => violette
         - sinon l'onglet s'affiche bien
       - cliquer sur catolog
           - ras 

_Si tu as lu cette description, pense a réagir avec un :eye:_
