### PR TITLE
Com 2977 2

### DIFF
--- a/src/core/helpers/utils.ts
+++ b/src/core/helpers/utils.ts
@@ -56,7 +56,7 @@ export const formatIdentity = (identity, format) => {
     values.push(value);
   }
 
-  return values.join(' ');
+  return values.join(' ').trim();
 };
 export const getCourseProgress = (course) => {
   if (course.format === STRICTLY_E_LEARNING) return course.progress.eLearning;

--- a/src/core/helpers/utils.ts
+++ b/src/core/helpers/utils.ts
@@ -43,7 +43,7 @@ export const achievementJingle = async () => {
 export const formatIdentity = (identity, format) => {
   if (!identity) return '';
   const formatLower = format.toLowerCase();
-  const values = [''];
+  const values: string[] = [];
 
   for (let i = 0; i < format.length; i += 1) {
     let value;
@@ -56,7 +56,7 @@ export const formatIdentity = (identity, format) => {
     values.push(value);
   }
 
-  return values.join(' ').trim();
+  return values.join(' ');
 };
 export const getCourseProgress = (course) => {
   if (course.format === STRICTLY_E_LEARNING) return course.progress.eLearning;

--- a/src/screens/courses/profile/TrainerCourseProfile/index.tsx
+++ b/src/screens/courses/profile/TrainerCourseProfile/index.tsx
@@ -93,7 +93,7 @@ const TrainerCourseProfile = ({
       <ScrollView nestedScrollEnabled={false} showsVerticalScrollIndicator={false}>
         <CourseProfileHeader source={source} goBack={goBack} title={title} />
         <View style={styles.buttonsContainer}>
-          <NiSecondaryButton caption='Espace admin' onPress={() => goTo(ADMIN_SCREEN)} icon='folder'
+          <NiSecondaryButton caption='Espace admin' onPress={() => goTo(ADMIN_SCREEN)} icon='folder' color={GREY[700]}
             customStyle={styles.adminButton} borderColor={GREY[200]} bgColor={GREY[200]} font={FIRA_SANS_MEDIUM.LG} />
           <NiSecondaryButton caption='A propos' onPress={() => goTo(ABOUT_SCREEN)} icon='info' borderColor={GREY[200]}
             bgColor={WHITE} font={FIRA_SANS_MEDIUM.LG} />


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone 🔴 simu
- [ ] J'ai testé sur android 🔴 je n'ai pas pu tester, mon tel de test ne s'allume pas
- [x] J'ai testé sur tablette 🔴 simu

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] Mes changements entrainent une incompatibilité avec l'ancienne version de l'api
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : formateur

- Cas d'usage :
  - suite a la vigilance de Manon et la confirmation de Romain, on a repassé ce ticket en PR pour deux raisons:
     - la plice du bouton "Espace admin' etait trop claire  
     - il y avait un espace avant les noms des stagiaires sur la liste

- Comment tester ? :
  - sur l'espace intervenant, sur la page trainerCourseProfil, le texte du bouton "Espace Admin" est en GREY[700] (plus sombre que celui de "a propos")
  - sur l'ecran "espace Admin", sur la liste des stagiaire, le nom des stagiaire est aligné avec l'email

_Si tu as lu cette description, pense a réagir avec un :eye:_
