### PR TITLE
Com 3251

### DIFF
--- a/src/core/data/constants.ts
+++ b/src/core/data/constants.ts
@@ -99,3 +99,7 @@ export const SIGNIN_ERROR = 'signinError';
 export const RESET_ERROR = 'resetError';
 export const SIGNOUT = 'signout';
 export const RENDER = 'render';
+
+// COMPANIDURATION FORMATS
+export const LONG_DURATION_H_MM = 'h\'h\' mm\'min\'';
+export const SHORT_DURATION_H_MM = 'h\'h\'mm';

--- a/src/core/helpers/dates/companiDurations.ts
+++ b/src/core/helpers/dates/companiDurations.ts
@@ -1,0 +1,77 @@
+import { SHORT_DURATION_H_MM, LONG_DURATION_H_MM } from '../../data/constants';
+import { Duration } from './luxon';
+
+const DURATION_HOURS = 'h\'h\'';
+const DURATION_MINUTES = 'm\'min\'';
+
+type DurationTypes = Duration | CompaniDurationType | string;
+
+type displayFormat = typeof SHORT_DURATION_H_MM | typeof LONG_DURATION_H_MM;
+
+type CompaniDurationType = {
+  _getDuration: Duration,
+  format: (template: displayFormat) => string,
+  asDays: () => Number,
+  toISO: () => string,
+  add: (miscTypeOtherDuration: DurationTypes) => CompaniDurationType,
+}
+
+const CompaniDurationFactory = (inputDuration: Duration): CompaniDurationType => {
+  const _duration = inputDuration;
+
+  return {
+    // GETTER
+    get _getDuration() {
+      return _duration;
+    },
+
+    // DISPLAY
+    format(template: displayFormat) {
+      const shiftedDuration = _duration.shiftTo('hours', 'minutes', 'seconds');
+      const minutes = shiftedDuration.get('minutes');
+      const hours = shiftedDuration.get('hours');
+
+      if (template === SHORT_DURATION_H_MM) {
+        if (minutes === 0) return _duration.toFormat(DURATION_HOURS);
+
+        return _duration.toFormat(SHORT_DURATION_H_MM);
+      } if (template === LONG_DURATION_H_MM) {
+        if (hours === 0) return _duration.toFormat(DURATION_MINUTES);
+        if (minutes === 0) return _duration.toFormat(DURATION_HOURS);
+
+        return _duration.toFormat(LONG_DURATION_H_MM);
+      }
+      throw Error('Invalid argument: expected specific format');
+    },
+
+    asDays() {
+      return _duration.as('days');
+    },
+
+    toISO() {
+      return _duration.toISO();
+    },
+
+    // MANIPULATE
+    add(miscTypeOtherDuration: DurationTypes) {
+      const otherDuration = _formatMiscToCompaniDuration(miscTypeOtherDuration);
+
+      return CompaniDurationFactory(_duration.plus(otherDuration));
+    },
+  };
+};
+
+const _formatMiscToCompaniDuration = (...args) => {
+  if (args.length === 0) return Duration.fromISO('PT0S');
+
+  if (args.length === 1) {
+    if (typeof args[0] === 'string') return Duration.fromISO(args[0]);
+
+    if (args[0] instanceof Object) {
+      if (args[0]._getDuration && args[0]._getDuration instanceof Duration) return args[0]._getDuration;
+    }
+  }
+  return Duration.invalid('wrong arguments');
+};
+
+export default (...args) => CompaniDurationFactory(_formatMiscToCompaniDuration(...args));

--- a/src/core/helpers/dates/companiDurations.ts
+++ b/src/core/helpers/dates/companiDurations.ts
@@ -4,7 +4,7 @@ import { Duration } from './luxon';
 const DURATION_HOURS = 'h\'h\'';
 const DURATION_MINUTES = 'm\'min\'';
 
-type DurationTypes = Duration | CompaniDurationType | string;
+type DurationTypes = CompaniDurationType | string;
 
 type displayFormat = typeof SHORT_DURATION_H_MM | typeof LONG_DURATION_H_MM;
 

--- a/src/core/helpers/dates/companiDurations.ts
+++ b/src/core/helpers/dates/companiDurations.ts
@@ -35,7 +35,8 @@ const CompaniDurationFactory = (inputDuration: Duration): CompaniDurationType =>
         if (minutes === 0) return _duration.toFormat(DURATION_HOURS);
 
         return _duration.toFormat(SHORT_DURATION_H_MM);
-      } if (template === LONG_DURATION_H_MM) {
+      }
+      if (template === LONG_DURATION_H_MM) {
         if (hours === 0) return _duration.toFormat(DURATION_MINUTES);
         if (minutes === 0) return _duration.toFormat(DURATION_HOURS);
 

--- a/src/core/helpers/dates/luxon.ts
+++ b/src/core/helpers/dates/luxon.ts
@@ -1,4 +1,4 @@
-import { Settings, DateTime, DateTimeUnit, ToRelativeUnit, DurationObjectUnits } from 'luxon';
+import { Settings, DateTime, Duration, DateTimeUnit, ToRelativeUnit, DurationObjectUnits } from 'luxon';
 import '@formatjs/intl-getcanonicallocales/polyfill';
 import '@formatjs/intl-locale/polyfill';
 import '@formatjs/intl-pluralrules/polyfill';
@@ -13,4 +13,4 @@ Settings.defaultLocale = 'fr';
 Settings.defaultZone = 'Europe/Paris';
 Settings.throwOnInvalid = true;
 
-export { DateTime, DateTimeUnit, ToRelativeUnit, DurationObjectUnits };
+export { DateTime, DateTimeUnit, Duration, ToRelativeUnit, DurationObjectUnits };

--- a/src/core/helpers/utils.ts
+++ b/src/core/helpers/utils.ts
@@ -1,6 +1,7 @@
 import { Audio } from 'expo-av';
 import BigNumber from 'bignumber.js';
-import { STRICTLY_E_LEARNING } from '../data/constants';
+import { STRICTLY_E_LEARNING, LONG_DURATION_H_MM } from '../data/constants';
+import CompaniDuration from '../helpers/dates/companiDurations';
 
 export const capitalize = (s) => {
   if (typeof s !== 'string') return '';
@@ -65,12 +66,10 @@ export const getCourseProgress = (course) => {
 };
 
 export const formatDuration = (durationHours) => {
-  const hours = Math.floor(durationHours);
-  const minutes = Math.round((durationHours % 1) * 60);
-  if (!hours) return `${minutes}min`;
-  if (!minutes) return `${hours}h`;
+  const durationInSeconds = durationHours * 3600;
+  const durationISO = `PT${durationInSeconds}S`;
 
-  return `${hours}h ${minutes.toString().padStart(2, '0')}min`;
+  return CompaniDuration(durationISO).format(LONG_DURATION_H_MM);
 };
 
 export const add = (...nums) => nums.reduce((acc, n) => new BigNumber(acc).plus(n).toNumber(), 0);


### PR DESCRIPTION
### TESTS  :computer:

- J'ai testé sur iphone : 
  - [x] simulateur
  - [ ] physique
- J'ai testé sur android :
  - [ ] simulateur
  - [x] physique
- [x] J'ai testé sur tablette

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de déploiement](https://www.notion.so/D-ploiement-et-distribution-mobile-7d25b02c0de448e2af7100151401d7e2) ce qu'il fallait mettre à jour
- [ ] Mes changements entrainent une incompatibilité avec l'ancienne version de l'api
  - [ ] Si oui, j'ai noté dans le [Doc de déploiement](https://www.notion.so/D-ploiement-et-distribution-mobile-7d25b02c0de448e2af7100151401d7e2) qu'il faut fusionner l'api dans staging avant d'envoyer le build


Rmq : 

 - je n'ai pas supprimé la methode formatDuration, je l'ai remaniée pour qu'elle accepte tjrs une durée en heure, float. Et que ca renvoie la durée en string HHh MMmin, tout en utilisant CompaniDuration afin de bien tester son fonctionnement sur mobile.

Chloé va supprimer cette mth dans la prochaine PR COM-3249

_Si tu as lu cette description, pense à réagir avec un :eye:_
