### PR TITLE
COM-3371 update libraries for github actions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
 
       # Check out the repository
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Install Node.js
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.18.0
 

--- a/.github/workflows/ts-lint.yml
+++ b/.github/workflows/ts-lint.yml
@@ -8,12 +8,12 @@ jobs:
     name: Run ESLint and Typescript test
     runs-on: ubuntu-latest
     steps:
-      
+
       # Check out the repository
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       # Install Node.js
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.18.0
 


### PR DESCRIPTION
Mise à jour des library actions/checkout et actions/setup-node car les actions utilisant node12 est bientot déprécié.
